### PR TITLE
Add DBC5 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ The rest of the code is manually written and is used for packing and unpacking R
 The pacmod3_common library can be compiled under both ROS1 and ROS2 in order to reduce duplication and code maintenance efforts.
 
 Each major version of the [pacmod DBC](https://github.com/astuff/pacmod_dbc) is supported by this pacmod3_common library.
+
+## Version Support
+
+Below is a table of supported DBC versions.
+
+|Major Version|Full DBC Version|
+|-|-|
+|3|3.4.1|
+|4|4.1.0|
+|5|5.0.0|

--- a/generate_code.bash
+++ b/generate_code.bash
@@ -27,10 +27,19 @@ main()
   cp "$TEMP_DIR/output/lib/$DRIVER_NAME.c" "$OUTPUT_DIR/"
   cp "$TEMP_DIR/output/lib/$DRIVER_NAME.h" "$OUTPUT_DIR/"
   cp "$TEMP_DIR/output/conf/$DRIVER_NAME-config.h" "$OUTPUT_DIR/"
-  # cp "$TEMP_DIR/output/conf/dbccodeconf.h" "$OUTPUT_DIR/"
+  if ! [ -e "$OUTPUT_DIR/dbccodeconf.h" ]; then
+    cp "$TEMP_DIR/output/conf/dbccodeconf.h" "$OUTPUT_DIR/"
+    sed -i "/\/\/ typedef double sigfloat_t;/c\typedef double sigfloat_t;" "$OUTPUT_DIR/dbccodeconf.h"
+    echo "" >> "$OUTPUT_DIR/dbccodeconf.h"
+    echo "typedef int64_t bitext_t;" >> "$OUTPUT_DIR/dbccodeconf.h"
+    echo "typedef uint64_t ubitext_t;" >> "$OUTPUT_DIR/dbccodeconf.h"
+  fi
+
+  # Enable USE_SIGFLOAT
+  sed -i "/#define PACMOD${DBC_MAJOR_VERSION}_USE_SIGFLOAT/c\#define PACMOD${DBC_MAJOR_VERSION}_USE_SIGFLOAT" "$OUTPUT_DIR/$DRIVER_NAME-config.h"
 
   # Pull out all CAN IDS:
-  grep -h "_CANID" "$OUTPUT_DIR/$DRIVER_NAME.h" > "dbc$DBC_MAJOR_VERSION.canids"
+  grep -h "_CANID" "$OUTPUT_DIR/$DRIVER_NAME.h" > "$OUTPUT_DIR/dbc$DBC_MAJOR_VERSION.canids"
 
   echo ""
   echo "Done"

--- a/include/pacmod3_dbc3_ros_api.h
+++ b/include/pacmod3_dbc3_ros_api.h
@@ -44,6 +44,7 @@ public:
   std::shared_ptr<void> ParseDateTimeRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseDetectedObjectRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseDoorRpt(const cn_msgs::Frame& can_msg) override;
+  std::shared_ptr<void> ParseEStopRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseEngineRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseGlobalRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseHeadlightAuxRpt(const cn_msgs::Frame& can_msg) override;

--- a/include/pacmod3_dbc4_ros_api.h
+++ b/include/pacmod3_dbc4_ros_api.h
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef PACMOD3_DBC12_ROS_API_H
-#define PACMOD3_DBC12_ROS_API_H
+#ifndef PACMOD3_DBC4_ROS_API_H
+#define PACMOD3_DBC4_ROS_API_H
 
 #include "pacmod3_dbc3_ros_api.h"
 
@@ -54,4 +54,4 @@ public:
 };
 }  // namespace pacmod3_common
 
-#endif  // PACMOD3_DBC12_ROS_API_H
+#endif  // PACMOD3_DBC4_ROS_API_H

--- a/include/pacmod3_dbc5_ros_api.h
+++ b/include/pacmod3_dbc5_ros_api.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 AutonomouStuff, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef PACMOD3_DBC12_ROS_API_H
+#define PACMOD3_DBC12_ROS_API_H
+
+#include "pacmod3_dbc4_ros_api.h"
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <mutex>
+
+namespace pacmod3_common
+{
+
+// Derived from previous DBC API version
+// The only overridden functions that exist here are due to changes to those msg types relative to the previous DBC version.
+class Dbc5Api : public Dbc4Api
+{
+public:
+  explicit Dbc5Api(uint32_t version = 4):Dbc4Api(version){};
+  virtual ~Dbc5Api() = default;
+
+  std::shared_ptr<void> ParseComponentRpt(const cn_msgs::Frame& can_msg) override;
+  std::shared_ptr<void> ParseShiftAuxRpt(const cn_msgs::Frame& can_msg) override;
+  std::shared_ptr<void> ParseWheelSpeedRpt(const cn_msgs::Frame& can_msg) override;
+};
+}  // namespace pacmod3_common
+
+#endif  // PACMOD3_DBC12_ROS_API_H

--- a/include/pacmod3_dbc5_ros_api.h
+++ b/include/pacmod3_dbc5_ros_api.h
@@ -40,6 +40,7 @@ public:
   virtual ~Dbc5Api() = default;
 
   std::shared_ptr<void> ParseComponentRpt(const cn_msgs::Frame& can_msg) override;
+  std::shared_ptr<void> ParseEStopRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseShiftAuxRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseWheelSpeedRpt(const cn_msgs::Frame& can_msg) override;
 };

--- a/include/pacmod3_dbc_ros_api.h
+++ b/include/pacmod3_dbc_ros_api.h
@@ -48,6 +48,7 @@
 #include <pacmod3_msgs/DetectedObjectRpt.h>
 #include <pacmod3_msgs/DoorRpt.h>
 #include <pacmod3_msgs/EngineRpt.h>
+#include <pacmod3_msgs/EStopRpt.h>
 #include <pacmod3_msgs/GlobalCmd.h>
 #include <pacmod3_msgs/GlobalRpt.h>
 #include <pacmod3_msgs/HeadlightAuxRpt.h>
@@ -96,6 +97,7 @@ namespace cn_msgs = can_msgs;
 #include <pacmod3_msgs/msg/detected_object_rpt.hpp>
 #include <pacmod3_msgs/msg/door_rpt.hpp>
 #include <pacmod3_msgs/msg/engine_rpt.hpp>
+#include <pacmod3_msgs/msg/estop_rpt.hpp>
 #include <pacmod3_msgs/msg/global_cmd.hpp>
 #include <pacmod3_msgs/msg/global_rpt.hpp>
 #include <pacmod3_msgs/msg/headlight_aux_rpt.hpp>
@@ -148,6 +150,7 @@ public:
   virtual std::shared_ptr<void> ParseDateTimeRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseDetectedObjectRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseDoorRpt(const cn_msgs::Frame& can_msg) = 0;
+  virtual std::shared_ptr<void> ParseEStopRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseEngineRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseGlobalRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseHeadlightAuxRpt(const cn_msgs::Frame& can_msg) = 0;

--- a/include/pacmod3_dbc_ros_api.h
+++ b/include/pacmod3_dbc_ros_api.h
@@ -38,6 +38,7 @@
 
 #include <can_msgs/Frame.h>
 
+// Only include the msgs that are currently supported by pacmod3_common
 #include <pacmod3_msgs/AccelAuxRpt.h>
 #include <pacmod3_msgs/AllSystemStatuses.h>
 #include <pacmod3_msgs/AngVelRpt.h>
@@ -85,6 +86,7 @@ namespace cn_msgs = can_msgs;
 
 #include <can_msgs/msg/frame.hpp>
 
+// Only include the msgs that are currently supported by pacmod3_common
 #include <pacmod3_msgs/msg/accel_aux_rpt.hpp>
 #include <pacmod3_msgs/msg/all_system_statuses.hpp>
 #include <pacmod3_msgs/msg/ang_vel_rpt.hpp>
@@ -138,6 +140,7 @@ public:
   virtual ~DbcApi() = default;
 
   // Parsing functions take in a ROS CAN msg and return a pointer to a ROS pacmod msg
+  // These virtual functions represent all the currently-supported pacmod reports across all DBC versions
   virtual std::shared_ptr<void> ParseAccelAuxRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseAngVelRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseBrakeAuxRpt(const cn_msgs::Frame& can_msg) = 0;
@@ -170,6 +173,7 @@ public:
   virtual std::shared_ptr<void> ParseYawRateRpt(const cn_msgs::Frame& can_msg) = 0;
 
   // Encoding functions take in a ROS pacmod msg and return and ROS CAN frame msg.
+  // These virtual functions represent all the currently-supported pacmod commands across all DBC versions
   virtual cn_msgs::Frame EncodeCmd(const pm_msgs::GlobalCmd& msg) = 0;
   virtual cn_msgs::Frame EncodeCmd(const pm_msgs::NotificationCmd& msg) = 0;
   virtual cn_msgs::Frame EncodeCmd(const pm_msgs::SteeringCmd& msg) = 0;

--- a/src/autogen/pacmod4.c
+++ b/src/autogen/pacmod4.c
@@ -9,6 +9,16 @@
 #endif // PACMOD4_USE_DIAG_MONITORS
 
 
+// To compile this function you need to typedef 'bitext_t' and 'ubitext_t'
+// globally in @dbccodeconf.h or locally in 'dbcdrvname'-config.h
+// Type selection may affect common performance. Most useful types are:
+// bitext_t : int64_t and ubitext_t : uint64_t
+static bitext_t __ext_sig__( ubitext_t val, uint8_t bits )
+{
+  ubitext_t const m = 1u << (bits - 1);
+  return (val ^ m) - m;
+}
+
 uint32_t Unpack_GLOBAL_RPT_pacmod4(GLOBAL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
@@ -28,7 +38,7 @@ uint32_t Unpack_GLOBAL_RPT_pacmod4(GLOBAL_RPT_t* _m, const uint8_t* _d, uint8_t 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_GLOBAL_RPT_pacmod4(&_m->mon1);
+  FMon_GLOBAL_RPT_pacmod4(&_m->mon1, GLOBAL_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return GLOBAL_RPT_CANID;
@@ -99,7 +109,7 @@ uint32_t Unpack_COMPONENT_RPT_00_pacmod4(COMPONENT_RPT_00_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_COMPONENT_RPT_00_pacmod4(&_m->mon1);
+  FMon_COMPONENT_RPT_00_pacmod4(&_m->mon1, COMPONENT_RPT_00_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return COMPONENT_RPT_00_CANID;
@@ -172,7 +182,7 @@ uint32_t Unpack_COMPONENT_RPT_01_pacmod4(COMPONENT_RPT_01_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_COMPONENT_RPT_01_pacmod4(&_m->mon1);
+  FMon_COMPONENT_RPT_01_pacmod4(&_m->mon1, COMPONENT_RPT_01_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return COMPONENT_RPT_01_CANID;
@@ -245,7 +255,7 @@ uint32_t Unpack_COMPONENT_RPT_02_pacmod4(COMPONENT_RPT_02_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_COMPONENT_RPT_02_pacmod4(&_m->mon1);
+  FMon_COMPONENT_RPT_02_pacmod4(&_m->mon1, COMPONENT_RPT_02_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return COMPONENT_RPT_02_CANID;
@@ -318,7 +328,7 @@ uint32_t Unpack_COMPONENT_RPT_03_pacmod4(COMPONENT_RPT_03_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_COMPONENT_RPT_03_pacmod4(&_m->mon1);
+  FMon_COMPONENT_RPT_03_pacmod4(&_m->mon1, COMPONENT_RPT_03_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return COMPONENT_RPT_03_CANID;
@@ -371,7 +381,7 @@ uint32_t Unpack_GLOBAL_CMD_pacmod4(GLOBAL_CMD_t* _m, const uint8_t* _d, uint8_t 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_GLOBAL_CMD_pacmod4(&_m->mon1);
+  FMon_GLOBAL_CMD_pacmod4(&_m->mon1, GLOBAL_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return GLOBAL_CMD_CANID;
@@ -422,7 +432,7 @@ uint32_t Unpack_ACCEL_CMD_pacmod4(ACCEL_CMD_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_ACCEL_CMD_pacmod4(&_m->mon1);
+  FMon_ACCEL_CMD_pacmod4(&_m->mon1, ACCEL_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return ACCEL_CMD_CANID;
@@ -485,7 +495,7 @@ uint32_t Unpack_BRAKE_CMD_pacmod4(BRAKE_CMD_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_CMD_pacmod4(&_m->mon1);
+  FMon_BRAKE_CMD_pacmod4(&_m->mon1, BRAKE_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_CMD_CANID;
@@ -545,7 +555,7 @@ uint32_t Unpack_CRUISE_CONTROL_BUTTONS_CMD_pacmod4(CRUISE_CONTROL_BUTTONS_CMD_t*
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_CRUISE_CONTROL_BUTTONS_CMD_pacmod4(&_m->mon1);
+  FMon_CRUISE_CONTROL_BUTTONS_CMD_pacmod4(&_m->mon1, CRUISE_CONTROL_BUTTONS_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return CRUISE_CONTROL_BUTTONS_CMD_CANID;
@@ -595,7 +605,7 @@ uint32_t Unpack_DASH_CONTROLS_LEFT_CMD_pacmod4(DASH_CONTROLS_LEFT_CMD_t* _m, con
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DASH_CONTROLS_LEFT_CMD_pacmod4(&_m->mon1);
+  FMon_DASH_CONTROLS_LEFT_CMD_pacmod4(&_m->mon1, DASH_CONTROLS_LEFT_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DASH_CONTROLS_LEFT_CMD_CANID;
@@ -645,7 +655,7 @@ uint32_t Unpack_DASH_CONTROLS_RIGHT_CMD_pacmod4(DASH_CONTROLS_RIGHT_CMD_t* _m, c
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DASH_CONTROLS_RIGHT_CMD_pacmod4(&_m->mon1);
+  FMon_DASH_CONTROLS_RIGHT_CMD_pacmod4(&_m->mon1, DASH_CONTROLS_RIGHT_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DASH_CONTROLS_RIGHT_CMD_CANID;
@@ -695,7 +705,7 @@ uint32_t Unpack_HAZARD_LIGHTS_CMD_pacmod4(HAZARD_LIGHTS_CMD_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HAZARD_LIGHTS_CMD_pacmod4(&_m->mon1);
+  FMon_HAZARD_LIGHTS_CMD_pacmod4(&_m->mon1, HAZARD_LIGHTS_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HAZARD_LIGHTS_CMD_CANID;
@@ -745,7 +755,7 @@ uint32_t Unpack_HEADLIGHT_CMD_pacmod4(HEADLIGHT_CMD_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HEADLIGHT_CMD_pacmod4(&_m->mon1);
+  FMon_HEADLIGHT_CMD_pacmod4(&_m->mon1, HEADLIGHT_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HEADLIGHT_CMD_CANID;
@@ -795,7 +805,7 @@ uint32_t Unpack_HORN_CMD_pacmod4(HORN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HORN_CMD_pacmod4(&_m->mon1);
+  FMon_HORN_CMD_pacmod4(&_m->mon1, HORN_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HORN_CMD_CANID;
@@ -845,7 +855,7 @@ uint32_t Unpack_MEDIA_CONTROLS_CMD_pacmod4(MEDIA_CONTROLS_CMD_t* _m, const uint8
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_MEDIA_CONTROLS_CMD_pacmod4(&_m->mon1);
+  FMon_MEDIA_CONTROLS_CMD_pacmod4(&_m->mon1, MEDIA_CONTROLS_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return MEDIA_CONTROLS_CMD_CANID;
@@ -895,7 +905,7 @@ uint32_t Unpack_PARKING_BRAKE_CMD_pacmod4(PARKING_BRAKE_CMD_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_PARKING_BRAKE_CMD_pacmod4(&_m->mon1);
+  FMon_PARKING_BRAKE_CMD_pacmod4(&_m->mon1, PARKING_BRAKE_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return PARKING_BRAKE_CMD_CANID;
@@ -945,7 +955,7 @@ uint32_t Unpack_SHIFT_CMD_pacmod4(SHIFT_CMD_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_SHIFT_CMD_pacmod4(&_m->mon1);
+  FMon_SHIFT_CMD_pacmod4(&_m->mon1, SHIFT_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return SHIFT_CMD_CANID;
@@ -988,7 +998,7 @@ uint32_t Unpack_STEERING_CMD_pacmod4(STEERING_CMD_t* _m, const uint8_t* _d, uint
   _m->ENABLE = (_d[0] & (0x01U));
   _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
   _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
-  _m->POSITION_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+  _m->POSITION_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->POSITION_phys = (sigfloat_t)(PACMOD4_POSITION_ro_fromS(_m->POSITION_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -1003,7 +1013,7 @@ uint32_t Unpack_STEERING_CMD_pacmod4(STEERING_CMD_t* _m, const uint8_t* _d, uint
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_CMD_pacmod4(&_m->mon1);
+  FMon_STEERING_CMD_pacmod4(&_m->mon1, STEERING_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_CMD_CANID;
@@ -1069,7 +1079,7 @@ uint32_t Unpack_TURN_CMD_pacmod4(TURN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_TURN_CMD_pacmod4(&_m->mon1);
+  FMon_TURN_CMD_pacmod4(&_m->mon1, TURN_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return TURN_CMD_CANID;
@@ -1119,7 +1129,7 @@ uint32_t Unpack_WIPER_CMD_pacmod4(WIPER_CMD_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_WIPER_CMD_pacmod4(&_m->mon1);
+  FMon_WIPER_CMD_pacmod4(&_m->mon1, WIPER_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return WIPER_CMD_CANID;
@@ -1187,7 +1197,7 @@ uint32_t Unpack_ACCEL_RPT_pacmod4(ACCEL_RPT_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_ACCEL_RPT_pacmod4(&_m->mon1);
+  FMon_ACCEL_RPT_pacmod4(&_m->mon1, ACCEL_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return ACCEL_RPT_CANID;
@@ -1277,7 +1287,7 @@ uint32_t Unpack_BRAKE_RPT_pacmod4(BRAKE_RPT_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_RPT_pacmod4(&_m->mon1);
+  FMon_BRAKE_RPT_pacmod4(&_m->mon1, BRAKE_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_RPT_CANID;
@@ -1356,7 +1366,7 @@ uint32_t Unpack_CRUISE_CONTROL_BUTTONS_RPT_pacmod4(CRUISE_CONTROL_BUTTONS_RPT_t*
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_CRUISE_CONTROL_BUTTONS_RPT_pacmod4(&_m->mon1);
+  FMon_CRUISE_CONTROL_BUTTONS_RPT_pacmod4(&_m->mon1, CRUISE_CONTROL_BUTTONS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return CRUISE_CONTROL_BUTTONS_RPT_CANID;
@@ -1417,7 +1427,7 @@ uint32_t Unpack_DASH_CONTROLS_LEFT_RPT_pacmod4(DASH_CONTROLS_LEFT_RPT_t* _m, con
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DASH_CONTROLS_LEFT_RPT_pacmod4(&_m->mon1);
+  FMon_DASH_CONTROLS_LEFT_RPT_pacmod4(&_m->mon1, DASH_CONTROLS_LEFT_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DASH_CONTROLS_LEFT_RPT_CANID;
@@ -1478,7 +1488,7 @@ uint32_t Unpack_DASH_CONTROLS_RIGHT_RPT_pacmod4(DASH_CONTROLS_RIGHT_RPT_t* _m, c
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DASH_CONTROLS_RIGHT_RPT_pacmod4(&_m->mon1);
+  FMon_DASH_CONTROLS_RIGHT_RPT_pacmod4(&_m->mon1, DASH_CONTROLS_RIGHT_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DASH_CONTROLS_RIGHT_RPT_CANID;
@@ -1539,7 +1549,7 @@ uint32_t Unpack_HAZARD_LIGHTS_RPT_pacmod4(HAZARD_LIGHTS_RPT_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HAZARD_LIGHTS_RPT_pacmod4(&_m->mon1);
+  FMon_HAZARD_LIGHTS_RPT_pacmod4(&_m->mon1, HAZARD_LIGHTS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HAZARD_LIGHTS_RPT_CANID;
@@ -1600,7 +1610,7 @@ uint32_t Unpack_HEADLIGHT_RPT_pacmod4(HEADLIGHT_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HEADLIGHT_RPT_pacmod4(&_m->mon1);
+  FMon_HEADLIGHT_RPT_pacmod4(&_m->mon1, HEADLIGHT_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HEADLIGHT_RPT_CANID;
@@ -1661,7 +1671,7 @@ uint32_t Unpack_HORN_RPT_pacmod4(HORN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HORN_RPT_pacmod4(&_m->mon1);
+  FMon_HORN_RPT_pacmod4(&_m->mon1, HORN_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HORN_RPT_CANID;
@@ -1722,7 +1732,7 @@ uint32_t Unpack_MEDIA_CONTROLS_RPT_pacmod4(MEDIA_CONTROLS_RPT_t* _m, const uint8
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_MEDIA_CONTROLS_RPT_pacmod4(&_m->mon1);
+  FMon_MEDIA_CONTROLS_RPT_pacmod4(&_m->mon1, MEDIA_CONTROLS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return MEDIA_CONTROLS_RPT_CANID;
@@ -1783,7 +1793,7 @@ uint32_t Unpack_PARKING_BRAKE_RPT_pacmod4(PARKING_BRAKE_RPT_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_PARKING_BRAKE_RPT_pacmod4(&_m->mon1);
+  FMon_PARKING_BRAKE_RPT_pacmod4(&_m->mon1, PARKING_BRAKE_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return PARKING_BRAKE_RPT_CANID;
@@ -1844,7 +1854,7 @@ uint32_t Unpack_SHIFT_RPT_pacmod4(SHIFT_RPT_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_SHIFT_RPT_pacmod4(&_m->mon1);
+  FMon_SHIFT_RPT_pacmod4(&_m->mon1, SHIFT_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return SHIFT_RPT_CANID;
@@ -1896,17 +1906,17 @@ uint32_t Unpack_STEERING_RPT_pacmod4(STEERING_RPT_t* _m, const uint8_t* _d, uint
   _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
   _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
   _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
-  _m->MANUAL_INPUT_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+  _m->MANUAL_INPUT_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->MANUAL_INPUT_phys = (sigfloat_t)(PACMOD4_MANUAL_INPUT_ro_fromS(_m->MANUAL_INPUT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->COMMANDED_VALUE_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+  _m->COMMANDED_VALUE_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->COMMANDED_VALUE_phys = (sigfloat_t)(PACMOD4_COMMANDED_VALUE_ro_fromS(_m->COMMANDED_VALUE_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->OUTPUT_VALUE_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+  _m->OUTPUT_VALUE_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->OUTPUT_VALUE_phys = (sigfloat_t)(PACMOD4_OUTPUT_VALUE_ro_fromS(_m->OUTPUT_VALUE_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -1916,7 +1926,7 @@ uint32_t Unpack_STEERING_RPT_pacmod4(STEERING_RPT_t* _m, const uint8_t* _d, uint
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_RPT_pacmod4(&_m->mon1);
+  FMon_STEERING_RPT_pacmod4(&_m->mon1, STEERING_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_RPT_CANID;
@@ -1995,7 +2005,7 @@ uint32_t Unpack_TURN_RPT_pacmod4(TURN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_TURN_RPT_pacmod4(&_m->mon1);
+  FMon_TURN_RPT_pacmod4(&_m->mon1, TURN_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return TURN_RPT_CANID;
@@ -2056,7 +2066,7 @@ uint32_t Unpack_WIPER_RPT_pacmod4(WIPER_RPT_t* _m, const uint8_t* _d, uint8_t dl
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_WIPER_RPT_pacmod4(&_m->mon1);
+  FMon_WIPER_RPT_pacmod4(&_m->mon1, WIPER_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return WIPER_RPT_CANID;
@@ -2100,12 +2110,12 @@ uint32_t Pack_WIPER_RPT_pacmod4(WIPER_RPT_t* _m, uint8_t* _d, uint8_t* _len, uin
 uint32_t Unpack_ACCEL_AUX_RPT_pacmod4(ACCEL_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->RAW_PEDAL_POS_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+  _m->RAW_PEDAL_POS_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->RAW_PEDAL_POS_phys = (sigfloat_t)(PACMOD4_RAW_PEDAL_POS_ro_fromS(_m->RAW_PEDAL_POS_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->RAW_PEDAL_FORCE_ro = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->RAW_PEDAL_FORCE_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->RAW_PEDAL_FORCE_phys = (sigfloat_t)(PACMOD4_RAW_PEDAL_FORCE_ro_fromS(_m->RAW_PEDAL_FORCE_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2120,7 +2130,7 @@ uint32_t Unpack_ACCEL_AUX_RPT_pacmod4(ACCEL_AUX_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_ACCEL_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_ACCEL_AUX_RPT_pacmod4(&_m->mon1, ACCEL_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return ACCEL_AUX_RPT_CANID;
@@ -2178,9 +2188,9 @@ uint32_t Pack_ACCEL_AUX_RPT_pacmod4(ACCEL_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _
 uint32_t Unpack_BRAKE_AUX_RPT_pacmod4(BRAKE_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->RAW_PEDAL_POS = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
-  _m->RAW_PEDAL_FORCE = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
-  _m->RAW_BRAKE_PRESSURE = ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU));
+  _m->RAW_PEDAL_POS = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->RAW_PEDAL_FORCE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->RAW_BRAKE_PRESSURE = __ext_sig__(( ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU)) ), 16);
   _m->USER_INTERACTION = (_d[6] & (0x01U));
   _m->BRAKE_ON_OFF = ((_d[6] >> 1) & (0x01U));
   _m->RAW_PEDAL_POS_IS_VALID = (_d[7] & (0x01U));
@@ -2194,7 +2204,7 @@ uint32_t Unpack_BRAKE_AUX_RPT_pacmod4(BRAKE_AUX_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_BRAKE_AUX_RPT_pacmod4(&_m->mon1, BRAKE_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_AUX_RPT_CANID;
@@ -2260,7 +2270,7 @@ uint32_t Unpack_HEADLIGHT_AUX_RPT_pacmod4(HEADLIGHT_AUX_RPT_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_HEADLIGHT_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_HEADLIGHT_AUX_RPT_pacmod4(&_m->mon1, HEADLIGHT_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return HEADLIGHT_AUX_RPT_CANID;
@@ -2316,7 +2326,7 @@ uint32_t Unpack_SHIFT_AUX_RPT_pacmod4(SHIFT_AUX_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_SHIFT_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_SHIFT_AUX_RPT_pacmod4(&_m->mon1, SHIFT_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return SHIFT_AUX_RPT_CANID;
@@ -2356,12 +2366,12 @@ uint32_t Pack_SHIFT_AUX_RPT_pacmod4(SHIFT_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _
 uint32_t Unpack_STEERING_AUX_RPT_pacmod4(STEERING_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->RAW_POSITION_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+  _m->RAW_POSITION_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->RAW_POSITION_phys = (sigfloat_t)(PACMOD4_RAW_POSITION_ro_fromS(_m->RAW_POSITION_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->RAW_TORQUE_ro = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->RAW_TORQUE_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->RAW_TORQUE_phys = (sigfloat_t)(PACMOD4_RAW_TORQUE_ro_fromS(_m->RAW_TORQUE_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2382,7 +2392,7 @@ uint32_t Unpack_STEERING_AUX_RPT_pacmod4(STEERING_AUX_RPT_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_STEERING_AUX_RPT_pacmod4(&_m->mon1, STEERING_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_AUX_RPT_CANID;
@@ -2456,7 +2466,7 @@ uint32_t Unpack_TURN_AUX_RPT_pacmod4(TURN_AUX_RPT_t* _m, const uint8_t* _d, uint
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_TURN_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_TURN_AUX_RPT_pacmod4(&_m->mon1, TURN_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return TURN_AUX_RPT_CANID;
@@ -2514,7 +2524,7 @@ uint32_t Unpack_WIPER_AUX_RPT_pacmod4(WIPER_AUX_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_WIPER_AUX_RPT_pacmod4(&_m->mon1);
+  FMon_WIPER_AUX_RPT_pacmod4(&_m->mon1, WIPER_AUX_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return WIPER_AUX_RPT_CANID;
@@ -2554,7 +2564,7 @@ uint32_t Pack_WIPER_AUX_RPT_pacmod4(WIPER_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _
 uint32_t Unpack_VEHICLE_SPEED_RPT_pacmod4(VEHICLE_SPEED_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->VEHICLE_SPEED_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+  _m->VEHICLE_SPEED_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->VEHICLE_SPEED_phys = (sigfloat_t)(PACMOD4_VEHICLE_SPEED_ro_fromS(_m->VEHICLE_SPEED_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2566,7 +2576,7 @@ uint32_t Unpack_VEHICLE_SPEED_RPT_pacmod4(VEHICLE_SPEED_RPT_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_VEHICLE_SPEED_RPT_pacmod4(&_m->mon1);
+  FMon_VEHICLE_SPEED_RPT_pacmod4(&_m->mon1, VEHICLE_SPEED_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return VEHICLE_SPEED_RPT_CANID;
@@ -2616,12 +2626,12 @@ uint32_t Pack_VEHICLE_SPEED_RPT_pacmod4(VEHICLE_SPEED_RPT_t* _m, uint8_t* _d, ui
 uint32_t Unpack_BRAKE_MOTOR_RPT_1_pacmod4(BRAKE_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->MOTOR_CURRENT_ro = ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->MOTOR_CURRENT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->MOTOR_CURRENT_phys = (sigfloat_t)(PACMOD4_MOTOR_CURRENT_ro_fromS(_m->MOTOR_CURRENT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->SHAFT_POSITION_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->SHAFT_POSITION_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->SHAFT_POSITION_phys = (sigfloat_t)(PACMOD4_SHAFT_POSITION_ro_fromS(_m->SHAFT_POSITION_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2631,7 +2641,7 @@ uint32_t Unpack_BRAKE_MOTOR_RPT_1_pacmod4(BRAKE_MOTOR_RPT_1_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_MOTOR_RPT_1_pacmod4(&_m->mon1);
+  FMon_BRAKE_MOTOR_RPT_1_pacmod4(&_m->mon1, BRAKE_MOTOR_RPT_1_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_MOTOR_RPT_1_CANID;
@@ -2693,9 +2703,9 @@ uint32_t Pack_BRAKE_MOTOR_RPT_1_pacmod4(BRAKE_MOTOR_RPT_1_t* _m, uint8_t* _d, ui
 uint32_t Unpack_BRAKE_MOTOR_RPT_2_pacmod4(BRAKE_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->ENCODER_TEMPERATURE = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
-  _m->MOTOR_TEMPERATURE = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
-  _m->ANGULAR_SPEED_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->ENCODER_TEMPERATURE = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->MOTOR_TEMPERATURE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->ANGULAR_SPEED_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->ANGULAR_SPEED_phys = (sigfloat_t)(PACMOD4_ANGULAR_SPEED_ro_fromS(_m->ANGULAR_SPEED_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2705,7 +2715,7 @@ uint32_t Unpack_BRAKE_MOTOR_RPT_2_pacmod4(BRAKE_MOTOR_RPT_2_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_MOTOR_RPT_2_pacmod4(&_m->mon1);
+  FMon_BRAKE_MOTOR_RPT_2_pacmod4(&_m->mon1, BRAKE_MOTOR_RPT_2_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_MOTOR_RPT_2_CANID;
@@ -2765,12 +2775,12 @@ uint32_t Pack_BRAKE_MOTOR_RPT_2_pacmod4(BRAKE_MOTOR_RPT_2_t* _m, uint8_t* _d, ui
 uint32_t Unpack_BRAKE_MOTOR_RPT_3_pacmod4(BRAKE_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->TORQUE_OUTPUT_ro = ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->TORQUE_OUTPUT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->TORQUE_OUTPUT_phys = (sigfloat_t)(PACMOD4_TORQUE_OUTPUT_ro_fromS(_m->TORQUE_OUTPUT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->TORQUE_INPUT_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->TORQUE_INPUT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->TORQUE_INPUT_phys = (sigfloat_t)(PACMOD4_TORQUE_INPUT_ro_fromS(_m->TORQUE_INPUT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2780,7 +2790,7 @@ uint32_t Unpack_BRAKE_MOTOR_RPT_3_pacmod4(BRAKE_MOTOR_RPT_3_t* _m, const uint8_t
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_BRAKE_MOTOR_RPT_3_pacmod4(&_m->mon1);
+  FMon_BRAKE_MOTOR_RPT_3_pacmod4(&_m->mon1, BRAKE_MOTOR_RPT_3_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return BRAKE_MOTOR_RPT_3_CANID;
@@ -2842,12 +2852,12 @@ uint32_t Pack_BRAKE_MOTOR_RPT_3_pacmod4(BRAKE_MOTOR_RPT_3_t* _m, uint8_t* _d, ui
 uint32_t Unpack_STEERING_MOTOR_RPT_1_pacmod4(STEERING_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->MOTOR_CURRENT_ro = ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->MOTOR_CURRENT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->MOTOR_CURRENT_phys = (sigfloat_t)(PACMOD4_MOTOR_CURRENT_ro_fromS(_m->MOTOR_CURRENT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->SHAFT_POSITION_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->SHAFT_POSITION_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->SHAFT_POSITION_phys = (sigfloat_t)(PACMOD4_SHAFT_POSITION_ro_fromS(_m->SHAFT_POSITION_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2857,7 +2867,7 @@ uint32_t Unpack_STEERING_MOTOR_RPT_1_pacmod4(STEERING_MOTOR_RPT_1_t* _m, const u
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_MOTOR_RPT_1_pacmod4(&_m->mon1);
+  FMon_STEERING_MOTOR_RPT_1_pacmod4(&_m->mon1, STEERING_MOTOR_RPT_1_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_MOTOR_RPT_1_CANID;
@@ -2919,9 +2929,9 @@ uint32_t Pack_STEERING_MOTOR_RPT_1_pacmod4(STEERING_MOTOR_RPT_1_t* _m, uint8_t* 
 uint32_t Unpack_STEERING_MOTOR_RPT_2_pacmod4(STEERING_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->ENCODER_TEMPERATURE = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
-  _m->MOTOR_TEMPERATURE = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
-  _m->ANGULAR_SPEED_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->ENCODER_TEMPERATURE = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->MOTOR_TEMPERATURE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->ANGULAR_SPEED_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->ANGULAR_SPEED_phys = (sigfloat_t)(PACMOD4_ANGULAR_SPEED_ro_fromS(_m->ANGULAR_SPEED_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -2931,7 +2941,7 @@ uint32_t Unpack_STEERING_MOTOR_RPT_2_pacmod4(STEERING_MOTOR_RPT_2_t* _m, const u
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_MOTOR_RPT_2_pacmod4(&_m->mon1);
+  FMon_STEERING_MOTOR_RPT_2_pacmod4(&_m->mon1, STEERING_MOTOR_RPT_2_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_MOTOR_RPT_2_CANID;
@@ -2991,12 +3001,12 @@ uint32_t Pack_STEERING_MOTOR_RPT_2_pacmod4(STEERING_MOTOR_RPT_2_t* _m, uint8_t* 
 uint32_t Unpack_STEERING_MOTOR_RPT_3_pacmod4(STEERING_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->TORQUE_OUTPUT_ro = ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->TORQUE_OUTPUT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->TORQUE_OUTPUT_phys = (sigfloat_t)(PACMOD4_TORQUE_OUTPUT_ro_fromS(_m->TORQUE_OUTPUT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->TORQUE_INPUT_ro = ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->TORQUE_INPUT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->TORQUE_INPUT_phys = (sigfloat_t)(PACMOD4_TORQUE_INPUT_ro_fromS(_m->TORQUE_INPUT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3006,7 +3016,7 @@ uint32_t Unpack_STEERING_MOTOR_RPT_3_pacmod4(STEERING_MOTOR_RPT_3_t* _m, const u
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_STEERING_MOTOR_RPT_3_pacmod4(&_m->mon1);
+  FMon_STEERING_MOTOR_RPT_3_pacmod4(&_m->mon1, STEERING_MOTOR_RPT_3_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return STEERING_MOTOR_RPT_3_CANID;
@@ -3073,17 +3083,17 @@ uint32_t Unpack_WHEEL_SPEED_RPT_pacmod4(WHEEL_SPEED_RPT_t* _m, const uint8_t* _d
   _m->WHEEL_SPD_FRONT_LEFT_phys = (sigfloat_t)(PACMOD4_WHEEL_SPD_FRONT_LEFT_ro_fromS(_m->WHEEL_SPD_FRONT_LEFT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->WHEEL_SPD_FRONT_RIGHT_ro = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+  _m->WHEEL_SPD_FRONT_RIGHT_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->WHEEL_SPD_FRONT_RIGHT_phys = (sigfloat_t)(PACMOD4_WHEEL_SPD_FRONT_RIGHT_ro_fromS(_m->WHEEL_SPD_FRONT_RIGHT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->WHEEL_SPD_REAR_LEFT_ro = ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU));
+  _m->WHEEL_SPD_REAR_LEFT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->WHEEL_SPD_REAR_LEFT_phys = (sigfloat_t)(PACMOD4_WHEEL_SPD_REAR_LEFT_ro_fromS(_m->WHEEL_SPD_REAR_LEFT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->WHEEL_SPD_REAR_RIGHT_ro = ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->WHEEL_SPD_REAR_RIGHT_ro = __ext_sig__(( ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->WHEEL_SPD_REAR_RIGHT_phys = (sigfloat_t)(PACMOD4_WHEEL_SPD_REAR_RIGHT_ro_fromS(_m->WHEEL_SPD_REAR_RIGHT_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3093,7 +3103,7 @@ uint32_t Unpack_WHEEL_SPEED_RPT_pacmod4(WHEEL_SPEED_RPT_t* _m, const uint8_t* _d
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_WHEEL_SPEED_RPT_pacmod4(&_m->mon1);
+  FMon_WHEEL_SPEED_RPT_pacmod4(&_m->mon1, WHEEL_SPEED_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return WHEEL_SPEED_RPT_CANID;
@@ -3159,7 +3169,7 @@ uint32_t Pack_WHEEL_SPEED_RPT_pacmod4(WHEEL_SPEED_RPT_t* _m, uint8_t* _d, uint8_
 uint32_t Unpack_YAW_RATE_RPT_pacmod4(YAW_RATE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->YAW_RATE_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+  _m->YAW_RATE_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->YAW_RATE_phys = (sigfloat_t)(PACMOD4_YAW_RATE_ro_fromS(_m->YAW_RATE_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3169,7 +3179,7 @@ uint32_t Unpack_YAW_RATE_RPT_pacmod4(YAW_RATE_RPT_t* _m, const uint8_t* _d, uint
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_YAW_RATE_RPT_pacmod4(&_m->mon1);
+  FMon_YAW_RATE_RPT_pacmod4(&_m->mon1, YAW_RATE_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return YAW_RATE_RPT_CANID;
@@ -3217,13 +3227,13 @@ uint32_t Pack_YAW_RATE_RPT_pacmod4(YAW_RATE_RPT_t* _m, uint8_t* _d, uint8_t* _le
 uint32_t Unpack_LAT_LON_HEADING_RPT_pacmod4(LAT_LON_HEADING_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
 {
   (void)dlc_;
-  _m->LATITUDE_DEGREES = (_d[0] & (0xFFU));
-  _m->LATITUDE_MINUTES = (_d[1] & (0xFFU));
-  _m->LATITUDE_SECONDS = (_d[2] & (0xFFU));
-  _m->LONGITUDE_DEGREES = (_d[3] & (0xFFU));
-  _m->LONGITUDE_MINUTES = (_d[4] & (0xFFU));
-  _m->LONGITUDE_SECONDS = (_d[5] & (0xFFU));
-  _m->HEADING_ro = ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+  _m->LATITUDE_DEGREES = __ext_sig__(( (_d[0] & (0xFFU)) ), 8);
+  _m->LATITUDE_MINUTES = __ext_sig__(( (_d[1] & (0xFFU)) ), 8);
+  _m->LATITUDE_SECONDS = __ext_sig__(( (_d[2] & (0xFFU)) ), 8);
+  _m->LONGITUDE_DEGREES = __ext_sig__(( (_d[3] & (0xFFU)) ), 8);
+  _m->LONGITUDE_MINUTES = __ext_sig__(( (_d[4] & (0xFFU)) ), 8);
+  _m->LONGITUDE_SECONDS = __ext_sig__(( (_d[5] & (0xFFU)) ), 8);
+  _m->HEADING_ro = __ext_sig__(( ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->HEADING_phys = (sigfloat_t)(PACMOD4_HEADING_ro_fromS(_m->HEADING_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3233,7 +3243,7 @@ uint32_t Unpack_LAT_LON_HEADING_RPT_pacmod4(LAT_LON_HEADING_RPT_t* _m, const uin
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_LAT_LON_HEADING_RPT_pacmod4(&_m->mon1);
+  FMon_LAT_LON_HEADING_RPT_pacmod4(&_m->mon1, LAT_LON_HEADING_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return LAT_LON_HEADING_RPT_CANID;
@@ -3317,7 +3327,7 @@ uint32_t Unpack_DATE_TIME_RPT_pacmod4(DATE_TIME_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DATE_TIME_RPT_pacmod4(&_m->mon1);
+  FMon_DATE_TIME_RPT_pacmod4(&_m->mon1, DATE_TIME_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DATE_TIME_RPT_CANID;
@@ -3392,7 +3402,7 @@ uint32_t Unpack_DETECTED_OBJECT_RPT_pacmod4(DETECTED_OBJECT_RPT_t* _m, const uin
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DETECTED_OBJECT_RPT_pacmod4(&_m->mon1);
+  FMon_DETECTED_OBJECT_RPT_pacmod4(&_m->mon1, DETECTED_OBJECT_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DETECTED_OBJECT_RPT_CANID;
@@ -3458,7 +3468,7 @@ uint32_t Unpack_VEH_SPECIFIC_RPT_1_pacmod4(VEH_SPECIFIC_RPT_1_t* _m, const uint8
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_VEH_SPECIFIC_RPT_1_pacmod4(&_m->mon1);
+  FMon_VEH_SPECIFIC_RPT_1_pacmod4(&_m->mon1, VEH_SPECIFIC_RPT_1_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return VEH_SPECIFIC_RPT_1_CANID;
@@ -3508,7 +3518,7 @@ uint32_t Unpack_VEH_DYNAMICS_RPT_pacmod4(VEH_DYNAMICS_RPT_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_VEH_DYNAMICS_RPT_pacmod4(&_m->mon1);
+  FMon_VEH_DYNAMICS_RPT_pacmod4(&_m->mon1, VEH_DYNAMICS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return VEH_DYNAMICS_RPT_CANID;
@@ -3563,7 +3573,7 @@ uint32_t Unpack_VIN_RPT_pacmod4(VIN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_VIN_RPT_pacmod4(&_m->mon1);
+  FMon_VIN_RPT_pacmod4(&_m->mon1, VIN_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return VIN_RPT_CANID;
@@ -3631,7 +3641,7 @@ uint32_t Unpack_OCCUPANCY_RPT_pacmod4(OCCUPANCY_RPT_t* _m, const uint8_t* _d, ui
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_OCCUPANCY_RPT_pacmod4(&_m->mon1);
+  FMon_OCCUPANCY_RPT_pacmod4(&_m->mon1, OCCUPANCY_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return OCCUPANCY_RPT_CANID;
@@ -3685,7 +3695,7 @@ uint32_t Unpack_INTERIOR_LIGHTS_RPT_pacmod4(INTERIOR_LIGHTS_RPT_t* _m, const uin
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_INTERIOR_LIGHTS_RPT_pacmod4(&_m->mon1);
+  FMon_INTERIOR_LIGHTS_RPT_pacmod4(&_m->mon1, INTERIOR_LIGHTS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return INTERIOR_LIGHTS_RPT_CANID;
@@ -3747,7 +3757,7 @@ uint32_t Unpack_DOOR_RPT_pacmod4(DOOR_RPT_t* _m, const uint8_t* _d, uint8_t dlc_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_DOOR_RPT_pacmod4(&_m->mon1);
+  FMon_DOOR_RPT_pacmod4(&_m->mon1, DOOR_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return DOOR_RPT_CANID;
@@ -3797,7 +3807,7 @@ uint32_t Unpack_REAR_LIGHTS_RPT_pacmod4(REAR_LIGHTS_RPT_t* _m, const uint8_t* _d
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_REAR_LIGHTS_RPT_pacmod4(&_m->mon1);
+  FMon_REAR_LIGHTS_RPT_pacmod4(&_m->mon1, REAR_LIGHTS_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return REAR_LIGHTS_RPT_CANID;
@@ -3843,17 +3853,17 @@ uint32_t Unpack_LINEAR_ACCEL_RPT_pacmod4(LINEAR_ACCEL_RPT_t* _m, const uint8_t* 
   _m->LATERAL_VALID = ((_d[0] >> 3) & (0x01U));
   _m->LONGITUDNAL_VALID = ((_d[0] >> 4) & (0x01U));
   _m->VERTICAL_VALID = ((_d[0] >> 5) & (0x01U));
-  _m->LATERAL_ACCEL_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+  _m->LATERAL_ACCEL_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->LATERAL_ACCEL_phys = (sigfloat_t)(PACMOD4_LATERAL_ACCEL_ro_fromS(_m->LATERAL_ACCEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->LONGITUDNAL_ACCEL_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+  _m->LONGITUDNAL_ACCEL_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->LONGITUDNAL_ACCEL_phys = (sigfloat_t)(PACMOD4_LONGITUDNAL_ACCEL_ro_fromS(_m->LONGITUDNAL_ACCEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->VERTICAL_ACCEL_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+  _m->VERTICAL_ACCEL_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->VERTICAL_ACCEL_phys = (sigfloat_t)(PACMOD4_VERTICAL_ACCEL_ro_fromS(_m->VERTICAL_ACCEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3863,7 +3873,7 @@ uint32_t Unpack_LINEAR_ACCEL_RPT_pacmod4(LINEAR_ACCEL_RPT_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_LINEAR_ACCEL_RPT_pacmod4(&_m->mon1);
+  FMon_LINEAR_ACCEL_RPT_pacmod4(&_m->mon1, LINEAR_ACCEL_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return LINEAR_ACCEL_RPT_CANID;
@@ -3931,17 +3941,17 @@ uint32_t Unpack_ANG_VEL_RPT_pacmod4(ANG_VEL_RPT_t* _m, const uint8_t* _d, uint8_
   _m->PITCH_VALID = ((_d[0] >> 3) & (0x01U));
   _m->ROLL_VALID = ((_d[0] >> 4) & (0x01U));
   _m->YAW_VALID = ((_d[0] >> 5) & (0x01U));
-  _m->PITCH_VEL_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+  _m->PITCH_VEL_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->PITCH_VEL_phys = (sigfloat_t)(PACMOD4_PITCH_VEL_ro_fromS(_m->PITCH_VEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->ROLL_VEL_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+  _m->ROLL_VEL_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->ROLL_VEL_phys = (sigfloat_t)(PACMOD4_ROLL_VEL_ro_fromS(_m->ROLL_VEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
 
-  _m->YAW_VEL_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+  _m->YAW_VEL_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
 #ifdef PACMOD4_USE_SIGFLOAT
   _m->YAW_VEL_phys = (sigfloat_t)(PACMOD4_YAW_VEL_ro_fromS(_m->YAW_VEL_ro));
 #endif // PACMOD4_USE_SIGFLOAT
@@ -3951,7 +3961,7 @@ uint32_t Unpack_ANG_VEL_RPT_pacmod4(ANG_VEL_RPT_t* _m, const uint8_t* _d, uint8_
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_ANG_VEL_RPT_pacmod4(&_m->mon1);
+  FMon_ANG_VEL_RPT_pacmod4(&_m->mon1, ANG_VEL_RPT_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return ANG_VEL_RPT_CANID;
@@ -4021,7 +4031,7 @@ uint32_t Unpack_NOTIFICATION_CMD_pacmod4(NOTIFICATION_CMD_t* _m, const uint8_t* 
   _m->mon1.last_cycle = GetSystemTick();
   _m->mon1.frame_cnt++;
 
-  FMon_NOTIFICATION_CMD_pacmod4(&_m->mon1);
+  FMon_NOTIFICATION_CMD_pacmod4(&_m->mon1, NOTIFICATION_CMD_CANID);
 #endif // PACMOD4_USE_DIAG_MONITORS
 
   return NOTIFICATION_CMD_CANID;

--- a/src/autogen/pacmod4.h
+++ b/src/autogen/pacmod4.h
@@ -34,12 +34,10 @@ typedef struct
 
   //  0 : "Control Disabled"
   //  1 : "Control Enabled"
-  // 
   uint8_t PACMOD_SYSTEM_ENABLED : 1;           //      Bits= 1
 
   //  0 : "Not Overridden"
   //  1 : "Overridden"
-  // 
   uint8_t PACMOD_SYSTEM_OVERRIDE_ACTIVE : 1;   //      Bits= 1
 
   uint8_t USR_CAN_TIMEOUT : 1;                 //      Bits= 1
@@ -48,7 +46,6 @@ typedef struct
 
   //  0 : "No Active CAN Timeout"
   //  1 : "Active CAN Timeout"
-  // 
   uint8_t BRK_CAN_TIMEOUT : 1;                 //      Bits= 1
 
   uint8_t PACMOD_SUBSYSTEM_TIMEOUT : 1;        //      Bits= 1
@@ -65,12 +62,10 @@ typedef struct
 
   //  0 : "Control Disabled"
   //  1 : "Control Enabled"
-  // 
   uint8_t PACMOD_SYSTEM_ENABLED;               //      Bits= 1
 
   //  0 : "Not Overridden"
   //  1 : "Overridden"
-  // 
   uint8_t PACMOD_SYSTEM_OVERRIDE_ACTIVE;       //      Bits= 1
 
   uint8_t USR_CAN_TIMEOUT;                     //      Bits= 1
@@ -79,7 +74,6 @@ typedef struct
 
   //  0 : "No Active CAN Timeout"
   //  1 : "Active CAN Timeout"
-  // 
   uint8_t BRK_CAN_TIMEOUT;                     //      Bits= 1
 
   uint8_t PACMOD_SUBSYSTEM_TIMEOUT;            //      Bits= 1
@@ -114,82 +108,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE : 4;                //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS : 1;        //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT : 1;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT : 1;           //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT : 1;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS : 1;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING : 1;                      //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG : 1;                      //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -200,17 +178,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT : 1;                  //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT : 1;             //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP : 1;                         //      Bits= 1
 
 #else
@@ -218,82 +193,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE;                    //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT;               //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS;                    //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG;                          //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -304,17 +263,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT;                      //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT;                 //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP;                             //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -339,82 +295,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE : 4;                //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS : 1;        //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT : 1;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT : 1;           //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT : 1;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS : 1;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING : 1;                      //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG : 1;                      //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -425,17 +365,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT : 1;                  //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT : 1;             //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP : 1;                         //      Bits= 1
 
 #else
@@ -443,82 +380,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE;                    //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT;               //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS;                    //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG;                          //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -529,17 +450,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT;                      //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT;                 //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP;                             //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -564,82 +482,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE : 4;                //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS : 1;        //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT : 1;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT : 1;           //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT : 1;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS : 1;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING : 1;                      //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG : 1;                      //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -650,17 +552,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT : 1;                  //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT : 1;             //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP : 1;                         //      Bits= 1
 
 #else
@@ -668,82 +567,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE;                    //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT;               //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS;                    //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG;                          //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -754,17 +637,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT;                      //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT;                 //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP;                             //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -789,82 +669,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE : 4;                //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS : 1;        //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT : 1;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT : 1;           //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT : 1;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS : 1;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE : 1;                 //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING : 1;                      //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN : 1;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER : 1;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG : 1;                      //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -875,17 +739,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT : 1;                  //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT : 1;             //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP : 1;                         //      Bits= 1
 
 #else
@@ -893,82 +754,66 @@ typedef struct
   //  0 : "PACMod"
   //  1 : "PACMini"
   //  2 : "PACMicro"
-  // 
   uint8_t COMPONENT_TYPE;                    //      Bits= 4
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t ACCEL;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t BRAKE;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t CRUISE_CONTROL_BUTTONS;            //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_LEFT;                //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t DASH_CONTROLS_RIGHT;               //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HAZARD_LIGHTS;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HEADLIGHT;                         //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t HORN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t MEDIA_CONTROLS;                    //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t PARKING_BRAKE;                     //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t SHIFT;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t STEERING;                          //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t TURN;                              //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WIPER;                             //      Bits= 1
 
   //  0 : "ABSENT"
   //  1 : "PRESENT"
-  // 
   uint8_t WATCHDOG;                          //      Bits= 1
 
   // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
@@ -979,17 +824,14 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CONFIG_FAULT;                      //      Bits= 1
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t CAN_TIMEOUT_FAULT;                 //      Bits= 1
 
   //  0 : "RELEASED"
   //  1 : "PRESSED"
-  // 
   uint8_t ESTOP;                             //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1147,7 +989,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t CRUISE_CONTROL_BUTTON;             //      Bits= 8
 
 #else
@@ -1165,7 +1006,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t CRUISE_CONTROL_BUTTON;             //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1199,7 +1039,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
 
 #else
@@ -1216,7 +1055,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1250,7 +1088,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
 
 #else
@@ -1267,7 +1104,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1335,7 +1171,6 @@ typedef struct
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t HEADLIGHT_CMD;                     //      Bits= 8
 
 #else
@@ -1349,7 +1184,6 @@ typedef struct
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t HEADLIGHT_CMD;                     //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1379,7 +1213,6 @@ typedef struct
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t HORN_CMD : 1;                      //      Bits= 1
 
 #else
@@ -1392,7 +1225,6 @@ typedef struct
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t HORN_CMD;                          //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1427,7 +1259,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t MEDIA_CONTROLS_CMD;                //      Bits= 8
 
 #else
@@ -1445,7 +1276,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t MEDIA_CONTROLS_CMD;                //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1517,7 +1347,6 @@ typedef struct
   //  3 : "FORWARD/HIGH"
   //  4 : "LOW"
   //  7 : "NONE"
-  // 
   uint8_t SHIFT_CMD;                         //      Bits= 8
 
 #else
@@ -1535,7 +1364,6 @@ typedef struct
   //  3 : "FORWARD/HIGH"
   //  4 : "LOW"
   //  7 : "NONE"
-  // 
   uint8_t SHIFT_CMD;                         //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1632,7 +1460,6 @@ typedef struct
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t TURN_SIGNAL_CMD;                   //      Bits= 8
 
 #else
@@ -1647,7 +1474,6 @@ typedef struct
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t TURN_SIGNAL_CMD;                   //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1683,7 +1509,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t WIPER_CMD;                         //      Bits= 8
 
 #else
@@ -1702,7 +1527,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t WIPER_CMD;                         //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -1752,7 +1576,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
@@ -1791,7 +1614,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
@@ -1859,7 +1681,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
@@ -1898,7 +1719,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
@@ -1954,7 +1774,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -1964,7 +1783,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -1974,7 +1792,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -1984,7 +1801,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2005,7 +1821,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -2015,7 +1830,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -2025,7 +1839,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  6 : "CRUISE_CONTROL_ON_OFF"
@@ -2035,7 +1848,6 @@ typedef struct
   //  2 : "CRUISE_CONTROL_ACC_FURTHER"
   //  1 : "CRUISE_CONTROL_CNCL"
   //  0 : "CRUISE_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2073,7 +1885,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2082,7 +1893,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2091,7 +1901,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2100,7 +1909,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2121,7 +1929,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2130,7 +1937,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2139,7 +1945,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2148,7 +1953,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2186,7 +1990,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2195,7 +1998,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2204,7 +2006,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2213,7 +2014,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2234,7 +2034,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2243,7 +2042,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2252,7 +2050,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  5 : "DASH_CONTROL_DOWN"
@@ -2261,7 +2058,6 @@ typedef struct
   //  2 : "DASH_CONTROL_LEFT"
   //  1 : "DASH_CONTROL_OK"
   //  0 : "DASH_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2299,7 +2095,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   uint8_t MANUAL_INPUT : 1;                  //      Bits= 1
@@ -2326,7 +2121,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   uint8_t MANUAL_INPUT;                      //      Bits= 1
@@ -2370,25 +2164,21 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2409,25 +2199,21 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  2 : "High Beams"
   //  1 : "Low Beams"
   //  0 : "Headlights Off"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2465,22 +2251,18 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2501,22 +2283,18 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "OFF"
   //  1 : "ON"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2554,7 +2332,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2564,7 +2341,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2574,7 +2350,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2584,7 +2359,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2605,7 +2379,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2615,7 +2388,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2625,7 +2397,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  6 : "MEDIA_CONTROL_VOL_DOWN"
@@ -2635,7 +2406,6 @@ typedef struct
   //  2 : "MEDIA_CONTROL_MUTE"
   //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
   //  0 : "MEDIA_CONTROL_NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2673,7 +2443,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   uint8_t MANUAL_INPUT : 1;                  //      Bits= 1
@@ -2700,7 +2469,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   uint8_t MANUAL_INPUT;                      //      Bits= 1
@@ -2744,7 +2512,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  0 : "PARK"
@@ -2755,7 +2522,6 @@ typedef struct
   //  5 : "BETWEEN_GEARS"
   //  6 : "ERROR"
   //  7 : "NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "PARK"
@@ -2764,7 +2530,6 @@ typedef struct
   //  3 : "FORWARD/HIGH"
   //  4 : "LOW"
   //  7 : "NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "PARK"
@@ -2775,7 +2540,6 @@ typedef struct
   //  5 : "BETWEEN_GEARS"
   //  6 : "ERROR"
   //  7 : "NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -2796,7 +2560,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  0 : "PARK"
@@ -2807,7 +2570,6 @@ typedef struct
   //  5 : "BETWEEN_GEARS"
   //  6 : "ERROR"
   //  7 : "NONE"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "PARK"
@@ -2816,7 +2578,6 @@ typedef struct
   //  3 : "FORWARD/HIGH"
   //  4 : "LOW"
   //  7 : "NONE"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "PARK"
@@ -2827,7 +2588,6 @@ typedef struct
   //  5 : "BETWEEN_GEARS"
   //  6 : "ERROR"
   //  7 : "NONE"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -2877,7 +2637,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   int16_t MANUAL_INPUT_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
@@ -2916,7 +2675,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   int16_t MANUAL_INPUT_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
@@ -2972,28 +2730,24 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -3014,28 +2768,24 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  0 : "RIGHT"
   //  1 : "NONE"
   //  2 : "LEFT"
   //  3 : "HAZARD"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -3073,7 +2823,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
 
   //  7 : "High"
@@ -3084,7 +2833,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  7 : "High"
@@ -3095,7 +2843,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  7 : "High"
@@ -3106,7 +2853,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #else
@@ -3127,7 +2873,6 @@ typedef struct
 
   //  0 : "NO_FAULT"
   //  1 : "FAULT"
-  // 
   uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
 
   //  7 : "High"
@@ -3138,7 +2883,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t MANUAL_INPUT;                      //      Bits= 8
 
   //  7 : "High"
@@ -3149,7 +2893,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t COMMANDED_VALUE;                   //      Bits= 8
 
   //  7 : "High"
@@ -3160,7 +2903,6 @@ typedef struct
   //  2 : "Intermittent 2"
   //  1 : "Intermittent 1"
   //  0 : "Wipers Off"
-  // 
   uint8_t OUTPUT_VALUE;                      //      Bits= 8
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -3322,7 +3064,6 @@ typedef struct
   //  2 : "Headlights On - Manual Mode"
   //  1 : "Parking Lights Only"
   //  0 : "Headlights Off"
-  // 
   uint8_t HEADLIGHTS_MODE;                     //      Bits= 8
 
   uint8_t HEADLIGHTS_ON_IS_VALID : 1;          //      Bits= 1
@@ -3345,7 +3086,6 @@ typedef struct
   //  2 : "Headlights On - Manual Mode"
   //  1 : "Parking Lights Only"
   //  0 : "Headlights Off"
-  // 
   uint8_t HEADLIGHTS_MODE;                     //      Bits= 8
 
   uint8_t HEADLIGHTS_ON_IS_VALID;              //      Bits= 1
@@ -3635,7 +3375,6 @@ typedef struct
 
   //  0 : "INVALID"
   //  1 : "VALID"
-  // 
   uint8_t VEHICLE_SPEED_VALID : 1;           //      Bits= 1
 
 #else
@@ -3648,7 +3387,6 @@ typedef struct
 
   //  0 : "INVALID"
   //  1 : "VALID"
-  // 
   uint8_t VEHICLE_SPEED_VALID;               //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL
@@ -4152,34 +3890,34 @@ typedef struct
 #define DATE_TIME_RPT_CANID (0x40f)
 // signal: @DATE_YEAR_ro
 #define PACMOD4_DATE_YEAR_ro_CovFactor (1)
-#define PACMOD4_DATE_YEAR_ro_toS(x) ( (uint16_t) ((x) - (2000)) )
+#define PACMOD4_DATE_YEAR_ro_toS(x) ( (uint8_t) ((x) - (2000)) )
 #define PACMOD4_DATE_YEAR_ro_fromS(x) ( ((x) + (2000)) )
 // signal: @DATE_MONTH_ro
 #define PACMOD4_DATE_MONTH_ro_CovFactor (1)
-#define PACMOD4_DATE_MONTH_ro_toS(x) ( (uint16_t) ((x) - (1)) )
+#define PACMOD4_DATE_MONTH_ro_toS(x) ( (uint8_t) ((x) - (1)) )
 #define PACMOD4_DATE_MONTH_ro_fromS(x) ( ((x) + (1)) )
 // signal: @DATE_DAY_ro
 #define PACMOD4_DATE_DAY_ro_CovFactor (1)
-#define PACMOD4_DATE_DAY_ro_toS(x) ( (uint16_t) ((x) - (1)) )
+#define PACMOD4_DATE_DAY_ro_toS(x) ( (uint8_t) ((x) - (1)) )
 #define PACMOD4_DATE_DAY_ro_fromS(x) ( ((x) + (1)) )
 
 typedef struct
 {
 #ifdef PACMOD4_USE_BITS_SIGNAL
 
-  uint16_t DATE_YEAR_ro;                     //      Bits= 8 Offset= 2000               Unit:'yr'
+  uint8_t DATE_YEAR_ro;                      //      Bits= 8 Offset= 2000               Unit:'yr'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_YEAR_phys;
 #endif // PACMOD4_USE_SIGFLOAT
 
-  uint16_t DATE_MONTH_ro;                    //      Bits= 8 Offset= 1                  Unit:'mon'
+  uint8_t DATE_MONTH_ro;                     //      Bits= 8 Offset= 1                  Unit:'mon'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_MONTH_phys;
 #endif // PACMOD4_USE_SIGFLOAT
 
-  uint16_t DATE_DAY_ro;                      //      Bits= 8 Offset= 1                  Unit:'dy'
+  uint8_t DATE_DAY_ro;                       //      Bits= 8 Offset= 1                  Unit:'dy'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_DAY_phys;
@@ -4193,19 +3931,19 @@ typedef struct
 
 #else
 
-  uint16_t DATE_YEAR_ro;                     //      Bits= 8 Offset= 2000               Unit:'yr'
+  uint8_t DATE_YEAR_ro;                      //      Bits= 8 Offset= 2000               Unit:'yr'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_YEAR_phys;
 #endif // PACMOD4_USE_SIGFLOAT
 
-  uint16_t DATE_MONTH_ro;                    //      Bits= 8 Offset= 1                  Unit:'mon'
+  uint8_t DATE_MONTH_ro;                     //      Bits= 8 Offset= 1                  Unit:'mon'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_MONTH_phys;
 #endif // PACMOD4_USE_SIGFLOAT
 
-  uint16_t DATE_DAY_ro;                      //      Bits= 8 Offset= 1                  Unit:'dy'
+  uint8_t DATE_DAY_ro;                       //      Bits= 8 Offset= 1                  Unit:'dy'
 
 #ifdef PACMOD4_USE_SIGFLOAT
   uint16_t DATE_DAY_phys;
@@ -4476,7 +4214,6 @@ typedef struct
   //  2 : "DIM_LEVEL_2"
   //  1 : "DIM_LEVEL_1"
   //  0 : "DIM_LEVEL_MIN"
-  // 
   uint8_t DIM_LEVEL;                           //      Bits= 8
 
   uint8_t FRONT_DOME_LIGHTS_ON_IS_VALID : 1;   //      Bits= 1
@@ -4508,7 +4245,6 @@ typedef struct
   //  2 : "DIM_LEVEL_2"
   //  1 : "DIM_LEVEL_1"
   //  0 : "DIM_LEVEL_MIN"
-  // 
   uint8_t DIM_LEVEL;                           //      Bits= 8
 
   uint8_t FRONT_DOME_LIGHTS_ON_IS_VALID;       //      Bits= 1
@@ -4666,32 +4402,26 @@ typedef struct
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t LATERAL_NEW_DATA_RX : 1;           //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t LONGITUDNAL_NEW_DATA_RX : 1;       //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t VERTICAL_NEW_DATA_RX : 1;          //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t LATERAL_VALID : 1;                 //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t LONGITUDNAL_VALID : 1;             //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t VERTICAL_VALID : 1;                //      Bits= 1
 
   int16_t LATERAL_ACCEL_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
@@ -4716,32 +4446,26 @@ typedef struct
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t LATERAL_NEW_DATA_RX;               //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t LONGITUDNAL_NEW_DATA_RX;           //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t VERTICAL_NEW_DATA_RX;              //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t LATERAL_VALID;                     //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t LONGITUDNAL_VALID;                 //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t VERTICAL_VALID;                    //      Bits= 1
 
   int16_t LATERAL_ACCEL_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
@@ -4795,32 +4519,26 @@ typedef struct
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t PITCH_NEW_DATA_RX : 1;             //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t ROLL_NEW_DATA_RX : 1;              //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t YAW_NEW_DATA_RX : 1;               //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t PITCH_VALID : 1;                   //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t ROLL_VALID : 1;                    //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t YAW_VALID : 1;                     //      Bits= 1
 
   int16_t PITCH_VEL_ro;                      //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
@@ -4845,32 +4563,26 @@ typedef struct
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t PITCH_NEW_DATA_RX;                 //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t ROLL_NEW_DATA_RX;                  //      Bits= 1
 
   //  0 : "NEW_DATA_NOT_RX"
   //  1 : "NEW_DATA_RX"
-  // 
   uint8_t YAW_NEW_DATA_RX;                   //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t PITCH_VALID;                       //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t ROLL_VALID;                        //      Bits= 1
 
   //  0 : "NOT_VALID"
   //  1 : "VALID"
-  // 
   uint8_t YAW_VALID;                         //      Bits= 1
 
   int16_t PITCH_VEL_ro;                      //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
@@ -4913,24 +4625,20 @@ typedef struct
 
   //  0 : "NOT_MUTED"
   //  1 : "MUTED"
-  // 
   uint8_t BUZZER_MUTE : 1;                   //      Bits= 1
 
   //  0 : "NO_ACTION"
   //  1 : "WHITE"
-  // 
   uint8_t UNDERDASH_LIGHTS_WHITE : 1;        //      Bits= 1
 
 #else
 
   //  0 : "NOT_MUTED"
   //  1 : "MUTED"
-  // 
   uint8_t BUZZER_MUTE;                       //      Bits= 1
 
   //  0 : "NO_ACTION"
   //  1 : "WHITE"
-  // 
   uint8_t UNDERDASH_LIGHTS_WHITE;            //      Bits= 1
 
 #endif // PACMOD4_USE_BITS_SIGNAL

--- a/src/autogen/pacmod5-config.h
+++ b/src/autogen/pacmod5-config.h
@@ -1,0 +1,109 @@
+#pragma once
+
+/* include common dbccode configurations */
+#include "dbccodeconf.h"
+
+
+/* ------------------------------------------------------------------------- *
+  This define enables using CAN message structs with bit-fielded signals
+  layout.
+
+  Note(!): bit-feild was not tested properly. */
+
+/* #define PACMOD5_USE_BITS_SIGNAL */
+
+
+/* ------------------------------------------------------------------------- *
+  This macro enables using CAN message descriptive struct packing functions
+  (by default signature of pack function intakes a few simple typed params
+  for loading data, len, etc). To compile you need to define the struct
+  __CoderDbcCanFrame_t__ which must have fields:
+
+    u32 MsgId (CAN Frame message ID)
+    u8 DLC (CAN Frame payload length field)
+    u8 Data[8] (CAN Frame payload data)
+    u8 IDE (CAN Frame Extended (1) / Standard (0) ID type)
+
+  This struct definition have to be placed (or be included) in dbccodeconf.h */
+
+/* #define PACMOD5_USE_CANSTRUCT */
+
+
+/* ------------------------------------------------------------------------- *
+  All the signals which have values of factor != 1 or offset != 0
+  will be named in message struct with posfix '_ro'. Pack to payload
+  operations will be made on this signal value as well as unpack from payload.
+
+  USE_SIGFLOAT macro makes some difference:
+
+  1. All the '_ro' fields will have a pair field with '_phys' postfix.
+  If only offset != 0 is true then the type of '_phys' signal is the same
+  as '_ro' signal. In other case the type will be @sigfloat_t which
+  have to be defined in user dbccodeconf.h
+
+  2. In pack function '_ro' signal will be rewritten by '_phys' signal, which
+  requires from user to use ONLY '_phys' signal for packing frame
+
+  3. In unpack function '_phys' signal will be written by '_ro' signal.
+  User have to use '_phys' signal to read physical value. */
+
+#define PACMOD5_USE_SIGFLOAT
+
+
+/* ------------------------------------------------------------------------- *
+  Note(!) that the "canmonitorutil.h" must be accessed in include path:
+
+  This macro adds:
+
+  - monitor field @mon1 to message struct
+
+  - capture system tick in unpack function and save value to mon1 field
+  to provide to user better missing frame detection code. For this case
+  user must provide function declared in canmonitorutil.h - GetSysTick()
+  which may return 1ms uptime.
+
+  - calling function FMon_***  (from 'fmon' driver) inside unpack function
+  which is empty by default and have to be filled by user if
+  tests for DLC, rolling, checksum are necessary */
+
+/* #define PACMOD5_USE_DIAG_MONITORS */
+
+
+/* ------------------------------------------------------------------------- *
+  When monitor using is enabled (PACMOD5_USE_DIAG_MONITORS) and define below
+  uncommented, additional signal will be added to message struct. ***_expt:
+  expected rolling counter, to perform monitoring rolling counter sequence
+  automatically (result may be tested in dedicated Fmon_*** function) */
+
+/* #define PACMOD5_AUTO_ROLL */
+
+
+/* ------------------------------------------------------------------------- *
+  When monitor using is enabled (PACMOD5_USE_DIAG_MONITORS) and define below
+  uncommented, frame checksum signal may be handled automatically.
+
+  The signal which may be marked as checksum signal must have substring
+  with next format:
+    <Checksum:XOR8:3>
+
+  where:
+
+  - "Checksum": constant marker word
+
+  - "XOR8": type of method, this text will be passed to GetFrameHash
+  (canmonitorutil.h) function as is, the best use case is to define 'enum
+  DbcCanCrcMethods' in canmonitorutil.h file with all possible
+  checksum algorithms (e.g. XOR8, XOR4 etc)
+
+  - "3": optional value that will be passed to GetFrameHash as integer value
+
+  Function GetFrameHash have to be implemented by user
+
+  In pack function checksum signal will be calculated automatically
+  and loaded to payload
+
+  In unpack function checksum signal is checked with calculated.
+  (result may be tested in dedicated Fmon_*** function). */
+
+/* #define PACMOD5_AUTO_CSM */
+

--- a/src/autogen/pacmod5.c
+++ b/src/autogen/pacmod5.c
@@ -1,0 +1,5054 @@
+#include "pacmod5.h"
+
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+// Function prototypes to be called each time CAN frame is unpacked
+// FMon function may detect RC, CRC or DLC violation
+#include "pacmod5-fmon.h"
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+
+// To compile this function you need to typedef 'bitext_t' and 'ubitext_t'
+// globally in @dbccodeconf.h or locally in 'dbcdrvname'-config.h
+// Type selection may affect common performance. Most useful types are:
+// bitext_t : int64_t and ubitext_t : uint64_t
+static bitext_t __ext_sig__( ubitext_t val, uint8_t bits )
+{
+  ubitext_t const m = 1u << (bits - 1);
+  return (val ^ m) - m;
+}
+
+uint32_t Unpack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->PACMOD_SYSTEM_ENABLED = (_d[0] & (0x01U));
+  _m->PACMOD_SYSTEM_OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->USR_CAN_TIMEOUT = ((_d[0] >> 2) & (0x01U));
+  _m->STR_CAN_TIMEOUT = ((_d[0] >> 3) & (0x01U));
+  _m->BRK_CAN_TIMEOUT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_SUBSYSTEM_TIMEOUT = ((_d[0] >> 5) & (0x01U));
+  _m->VEH_CAN_TIMEOUT = ((_d[0] >> 6) & (0x01U));
+  _m->PACMOD_SYSTEM_FAULT_ACTIVE = ((_d[0] >> 7) & (0x01U));
+  _m->CONFIG_FAULT_ACTIVE = ((_d[1] >> 7) & (0x01U));
+  _m->USR_CAN_READ_ERRORS = ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < GLOBAL_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_GLOBAL_RPT_pacmod5(&_m->mon1, GLOBAL_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return GLOBAL_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < GLOBAL_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->PACMOD_SYSTEM_ENABLED & (0x01U)) | ((_m->PACMOD_SYSTEM_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->USR_CAN_TIMEOUT & (0x01U)) << 2) | ((_m->STR_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->BRK_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->PACMOD_SUBSYSTEM_TIMEOUT & (0x01U)) << 5) | ((_m->VEH_CAN_TIMEOUT & (0x01U)) << 6) | ((_m->PACMOD_SYSTEM_FAULT_ACTIVE & (0x01U)) << 7);
+  cframe->Data[1] |= ((_m->CONFIG_FAULT_ACTIVE & (0x01U)) << 7);
+  cframe->Data[6] |= ((_m->USR_CAN_READ_ERRORS >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->USR_CAN_READ_ERRORS & (0xFFU));
+
+  cframe->MsgId = GLOBAL_RPT_CANID;
+  cframe->DLC = GLOBAL_RPT_DLC;
+  cframe->IDE = GLOBAL_RPT_IDE;
+  return GLOBAL_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < GLOBAL_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->PACMOD_SYSTEM_ENABLED & (0x01U)) | ((_m->PACMOD_SYSTEM_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->USR_CAN_TIMEOUT & (0x01U)) << 2) | ((_m->STR_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->BRK_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->PACMOD_SUBSYSTEM_TIMEOUT & (0x01U)) << 5) | ((_m->VEH_CAN_TIMEOUT & (0x01U)) << 6) | ((_m->PACMOD_SYSTEM_FAULT_ACTIVE & (0x01U)) << 7);
+  _d[1] |= ((_m->CONFIG_FAULT_ACTIVE & (0x01U)) << 7);
+  _d[6] |= ((_m->USR_CAN_READ_ERRORS >> 8) & (0xFFU));
+  _d[7] |= (_m->USR_CAN_READ_ERRORS & (0xFFU));
+
+  *_len = GLOBAL_RPT_DLC;
+  *_ide = GLOBAL_RPT_IDE;
+  return GLOBAL_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->COMPONENT_TYPE = (_d[0] & (0x0FU));
+  _m->ACCEL = ((_d[0] >> 4) & (0x01U));
+  _m->BRAKE = ((_d[0] >> 5) & (0x01U));
+  _m->CRUISE_CONTROL_BUTTONS = ((_d[0] >> 6) & (0x01U));
+  _m->DASH_CONTROLS_LEFT = ((_d[0] >> 7) & (0x01U));
+  _m->DASH_CONTROLS_RIGHT = (_d[1] & (0x01U));
+  _m->HAZARD_LIGHTS = ((_d[1] >> 1) & (0x01U));
+  _m->HEADLIGHT = ((_d[1] >> 2) & (0x01U));
+  _m->HORN = ((_d[1] >> 3) & (0x01U));
+  _m->MEDIA_CONTROLS = ((_d[1] >> 4) & (0x01U));
+  _m->PARKING_BRAKE = ((_d[1] >> 5) & (0x01U));
+  _m->SHIFT = ((_d[1] >> 6) & (0x01U));
+  _m->SPRAY = ((_d[1] >> 7) & (0x01U));
+  _m->STEERING = (_d[2] & (0x01U));
+  _m->TURN = ((_d[2] >> 1) & (0x01U));
+  _m->WIPER = ((_d[2] >> 2) & (0x01U));
+  _m->WATCHDOG = ((_d[2] >> 3) & (0x01U));
+  _m->BRAKE_DECCEL = ((_d[2] >> 4) & (0x01U));
+  _m->COUNTER = (_d[4] & (0x0FU));
+  _m->COMPLEMENT = ((_d[4] >> 4) & (0x0FU));
+  _m->CONFIG_FAULT = (_d[5] & (0x01U));
+  _m->CAN_TIMEOUT_FAULT = ((_d[5] >> 1) & (0x01U));
+  _m->INTERNAL_SUPPLY_VOLTAGE_FAULT = ((_d[5] >> 2) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < COMPONENT_RPT_00_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_COMPONENT_RPT_00_pacmod5(&_m->mon1, COMPONENT_RPT_00_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return COMPONENT_RPT_00_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_00_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  cframe->Data[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  cframe->Data[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  cframe->Data[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  cframe->MsgId = COMPONENT_RPT_00_CANID;
+  cframe->DLC = COMPONENT_RPT_00_DLC;
+  cframe->IDE = COMPONENT_RPT_00_IDE;
+  return COMPONENT_RPT_00_CANID;
+}
+
+#else
+
+uint32_t Pack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_00_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  _d[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  _d[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  _d[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  _d[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  *_len = COMPONENT_RPT_00_DLC;
+  *_ide = COMPONENT_RPT_00_IDE;
+  return COMPONENT_RPT_00_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->COMPONENT_TYPE = (_d[0] & (0x0FU));
+  _m->ACCEL = ((_d[0] >> 4) & (0x01U));
+  _m->BRAKE = ((_d[0] >> 5) & (0x01U));
+  _m->CRUISE_CONTROL_BUTTONS = ((_d[0] >> 6) & (0x01U));
+  _m->DASH_CONTROLS_LEFT = ((_d[0] >> 7) & (0x01U));
+  _m->DASH_CONTROLS_RIGHT = (_d[1] & (0x01U));
+  _m->HAZARD_LIGHTS = ((_d[1] >> 1) & (0x01U));
+  _m->HEADLIGHT = ((_d[1] >> 2) & (0x01U));
+  _m->HORN = ((_d[1] >> 3) & (0x01U));
+  _m->MEDIA_CONTROLS = ((_d[1] >> 4) & (0x01U));
+  _m->PARKING_BRAKE = ((_d[1] >> 5) & (0x01U));
+  _m->SHIFT = ((_d[1] >> 6) & (0x01U));
+  _m->SPRAY = ((_d[1] >> 7) & (0x01U));
+  _m->STEERING = (_d[2] & (0x01U));
+  _m->TURN = ((_d[2] >> 1) & (0x01U));
+  _m->WIPER = ((_d[2] >> 2) & (0x01U));
+  _m->WATCHDOG = ((_d[2] >> 3) & (0x01U));
+  _m->BRAKE_DECCEL = ((_d[2] >> 4) & (0x01U));
+  _m->COUNTER = (_d[4] & (0x0FU));
+  _m->COMPLEMENT = ((_d[4] >> 4) & (0x0FU));
+  _m->CONFIG_FAULT = (_d[5] & (0x01U));
+  _m->CAN_TIMEOUT_FAULT = ((_d[5] >> 1) & (0x01U));
+  _m->INTERNAL_SUPPLY_VOLTAGE_FAULT = ((_d[5] >> 2) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < COMPONENT_RPT_01_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_COMPONENT_RPT_01_pacmod5(&_m->mon1, COMPONENT_RPT_01_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return COMPONENT_RPT_01_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_01_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  cframe->Data[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  cframe->Data[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  cframe->Data[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  cframe->MsgId = COMPONENT_RPT_01_CANID;
+  cframe->DLC = COMPONENT_RPT_01_DLC;
+  cframe->IDE = COMPONENT_RPT_01_IDE;
+  return COMPONENT_RPT_01_CANID;
+}
+
+#else
+
+uint32_t Pack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_01_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  _d[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  _d[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  _d[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  _d[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  *_len = COMPONENT_RPT_01_DLC;
+  *_ide = COMPONENT_RPT_01_IDE;
+  return COMPONENT_RPT_01_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->COMPONENT_TYPE = (_d[0] & (0x0FU));
+  _m->ACCEL = ((_d[0] >> 4) & (0x01U));
+  _m->BRAKE = ((_d[0] >> 5) & (0x01U));
+  _m->CRUISE_CONTROL_BUTTONS = ((_d[0] >> 6) & (0x01U));
+  _m->DASH_CONTROLS_LEFT = ((_d[0] >> 7) & (0x01U));
+  _m->DASH_CONTROLS_RIGHT = (_d[1] & (0x01U));
+  _m->HAZARD_LIGHTS = ((_d[1] >> 1) & (0x01U));
+  _m->HEADLIGHT = ((_d[1] >> 2) & (0x01U));
+  _m->HORN = ((_d[1] >> 3) & (0x01U));
+  _m->MEDIA_CONTROLS = ((_d[1] >> 4) & (0x01U));
+  _m->PARKING_BRAKE = ((_d[1] >> 5) & (0x01U));
+  _m->SHIFT = ((_d[1] >> 6) & (0x01U));
+  _m->SPRAY = ((_d[1] >> 7) & (0x01U));
+  _m->STEERING = (_d[2] & (0x01U));
+  _m->TURN = ((_d[2] >> 1) & (0x01U));
+  _m->WIPER = ((_d[2] >> 2) & (0x01U));
+  _m->WATCHDOG = ((_d[2] >> 3) & (0x01U));
+  _m->BRAKE_DECCEL = ((_d[2] >> 4) & (0x01U));
+  _m->COUNTER = (_d[4] & (0x0FU));
+  _m->COMPLEMENT = ((_d[4] >> 4) & (0x0FU));
+  _m->CONFIG_FAULT = (_d[5] & (0x01U));
+  _m->CAN_TIMEOUT_FAULT = ((_d[5] >> 1) & (0x01U));
+  _m->INTERNAL_SUPPLY_VOLTAGE_FAULT = ((_d[5] >> 2) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < COMPONENT_RPT_02_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_COMPONENT_RPT_02_pacmod5(&_m->mon1, COMPONENT_RPT_02_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return COMPONENT_RPT_02_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_02_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  cframe->Data[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  cframe->Data[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  cframe->Data[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  cframe->MsgId = COMPONENT_RPT_02_CANID;
+  cframe->DLC = COMPONENT_RPT_02_DLC;
+  cframe->IDE = COMPONENT_RPT_02_IDE;
+  return COMPONENT_RPT_02_CANID;
+}
+
+#else
+
+uint32_t Pack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_02_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  _d[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  _d[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  _d[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  _d[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  *_len = COMPONENT_RPT_02_DLC;
+  *_ide = COMPONENT_RPT_02_IDE;
+  return COMPONENT_RPT_02_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->COMPONENT_TYPE = (_d[0] & (0x0FU));
+  _m->ACCEL = ((_d[0] >> 4) & (0x01U));
+  _m->BRAKE = ((_d[0] >> 5) & (0x01U));
+  _m->CRUISE_CONTROL_BUTTONS = ((_d[0] >> 6) & (0x01U));
+  _m->DASH_CONTROLS_LEFT = ((_d[0] >> 7) & (0x01U));
+  _m->DASH_CONTROLS_RIGHT = (_d[1] & (0x01U));
+  _m->HAZARD_LIGHTS = ((_d[1] >> 1) & (0x01U));
+  _m->HEADLIGHT = ((_d[1] >> 2) & (0x01U));
+  _m->HORN = ((_d[1] >> 3) & (0x01U));
+  _m->MEDIA_CONTROLS = ((_d[1] >> 4) & (0x01U));
+  _m->PARKING_BRAKE = ((_d[1] >> 5) & (0x01U));
+  _m->SHIFT = ((_d[1] >> 6) & (0x01U));
+  _m->SPRAY = ((_d[1] >> 7) & (0x01U));
+  _m->STEERING = (_d[2] & (0x01U));
+  _m->TURN = ((_d[2] >> 1) & (0x01U));
+  _m->WIPER = ((_d[2] >> 2) & (0x01U));
+  _m->WATCHDOG = ((_d[2] >> 3) & (0x01U));
+  _m->BRAKE_DECCEL = ((_d[2] >> 4) & (0x01U));
+  _m->COUNTER = (_d[4] & (0x0FU));
+  _m->COMPLEMENT = ((_d[4] >> 4) & (0x0FU));
+  _m->CONFIG_FAULT = (_d[5] & (0x01U));
+  _m->CAN_TIMEOUT_FAULT = ((_d[5] >> 1) & (0x01U));
+  _m->INTERNAL_SUPPLY_VOLTAGE_FAULT = ((_d[5] >> 2) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < COMPONENT_RPT_03_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_COMPONENT_RPT_03_pacmod5(&_m->mon1, COMPONENT_RPT_03_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return COMPONENT_RPT_03_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_03_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  cframe->Data[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  cframe->Data[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  cframe->Data[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  cframe->MsgId = COMPONENT_RPT_03_CANID;
+  cframe->DLC = COMPONENT_RPT_03_DLC;
+  cframe->IDE = COMPONENT_RPT_03_IDE;
+  return COMPONENT_RPT_03_CANID;
+}
+
+#else
+
+uint32_t Pack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < COMPONENT_RPT_03_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->COMPONENT_TYPE & (0x0FU)) | ((_m->ACCEL & (0x01U)) << 4) | ((_m->BRAKE & (0x01U)) << 5) | ((_m->CRUISE_CONTROL_BUTTONS & (0x01U)) << 6) | ((_m->DASH_CONTROLS_LEFT & (0x01U)) << 7);
+  _d[1] |= (_m->DASH_CONTROLS_RIGHT & (0x01U)) | ((_m->HAZARD_LIGHTS & (0x01U)) << 1) | ((_m->HEADLIGHT & (0x01U)) << 2) | ((_m->HORN & (0x01U)) << 3) | ((_m->MEDIA_CONTROLS & (0x01U)) << 4) | ((_m->PARKING_BRAKE & (0x01U)) << 5) | ((_m->SHIFT & (0x01U)) << 6) | ((_m->SPRAY & (0x01U)) << 7);
+  _d[2] |= (_m->STEERING & (0x01U)) | ((_m->TURN & (0x01U)) << 1) | ((_m->WIPER & (0x01U)) << 2) | ((_m->WATCHDOG & (0x01U)) << 3) | ((_m->BRAKE_DECCEL & (0x01U)) << 4);
+  _d[4] |= (_m->COUNTER & (0x0FU)) | ((_m->COMPLEMENT & (0x0FU)) << 4);
+  _d[5] |= (_m->CONFIG_FAULT & (0x01U)) | ((_m->CAN_TIMEOUT_FAULT & (0x01U)) << 1) | ((_m->INTERNAL_SUPPLY_VOLTAGE_FAULT & (0x01U)) << 2);
+
+  *_len = COMPONENT_RPT_03_DLC;
+  *_ide = COMPONENT_RPT_03_IDE;
+  return COMPONENT_RPT_03_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->CLEAR_FAULTS = (_d[0] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < GLOBAL_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_GLOBAL_CMD_pacmod5(&_m->mon1, GLOBAL_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return GLOBAL_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < GLOBAL_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->CLEAR_FAULTS & (0x01U));
+
+  cframe->MsgId = GLOBAL_CMD_CANID;
+  cframe->DLC = GLOBAL_CMD_DLC;
+  cframe->IDE = GLOBAL_CMD_IDE;
+  return GLOBAL_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < GLOBAL_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->CLEAR_FAULTS & (0x01U));
+
+  *_len = GLOBAL_CMD_DLC;
+  *_ide = GLOBAL_CMD_IDE;
+  return GLOBAL_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->ACCEL_CMD_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_phys = (sigfloat_t)(PACMOD5_ACCEL_CMD_ro_fromS(_m->ACCEL_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ACCEL_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ACCEL_CMD_pacmod5(&_m->mon1, ACCEL_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ACCEL_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_ro = PACMOD5_ACCEL_CMD_ro_toS(_m->ACCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= ((_m->ACCEL_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->ACCEL_CMD_ro & (0xFFU));
+
+  cframe->MsgId = ACCEL_CMD_CANID;
+  cframe->DLC = ACCEL_CMD_DLC;
+  cframe->IDE = ACCEL_CMD_IDE;
+  return ACCEL_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_ro = PACMOD5_ACCEL_CMD_ro_toS(_m->ACCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= ((_m->ACCEL_CMD_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->ACCEL_CMD_ro & (0xFFU));
+
+  *_len = ACCEL_CMD_DLC;
+  *_ide = ACCEL_CMD_IDE;
+  return ACCEL_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->BRAKE_CMD_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_phys = (sigfloat_t)(PACMOD5_BRAKE_CMD_ro_fromS(_m->BRAKE_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_CMD_pacmod5(&_m->mon1, BRAKE_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_ro = PACMOD5_BRAKE_CMD_ro_toS(_m->BRAKE_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= ((_m->BRAKE_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->BRAKE_CMD_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_CMD_CANID;
+  cframe->DLC = BRAKE_CMD_DLC;
+  cframe->IDE = BRAKE_CMD_IDE;
+  return BRAKE_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_ro = PACMOD5_BRAKE_CMD_ro_toS(_m->BRAKE_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= ((_m->BRAKE_CMD_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->BRAKE_CMD_ro & (0xFFU));
+
+  *_len = BRAKE_CMD_DLC;
+  *_ide = BRAKE_CMD_IDE;
+  return BRAKE_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->CRUISE_CONTROL_BUTTON = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < CRUISE_CONTROL_BUTTONS_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(&_m->mon1, CRUISE_CONTROL_BUTTONS_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return CRUISE_CONTROL_BUTTONS_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < CRUISE_CONTROL_BUTTONS_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->CRUISE_CONTROL_BUTTON & (0xFFU));
+
+  cframe->MsgId = CRUISE_CONTROL_BUTTONS_CMD_CANID;
+  cframe->DLC = CRUISE_CONTROL_BUTTONS_CMD_DLC;
+  cframe->IDE = CRUISE_CONTROL_BUTTONS_CMD_IDE;
+  return CRUISE_CONTROL_BUTTONS_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < CRUISE_CONTROL_BUTTONS_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->CRUISE_CONTROL_BUTTON & (0xFFU));
+
+  *_len = CRUISE_CONTROL_BUTTONS_CMD_DLC;
+  *_ide = CRUISE_CONTROL_BUTTONS_CMD_IDE;
+  return CRUISE_CONTROL_BUTTONS_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->DASH_CONTROLS_BUTTON = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DASH_CONTROLS_LEFT_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DASH_CONTROLS_LEFT_CMD_pacmod5(&_m->mon1, DASH_CONTROLS_LEFT_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DASH_CONTROLS_LEFT_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_LEFT_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_BUTTON & (0xFFU));
+
+  cframe->MsgId = DASH_CONTROLS_LEFT_CMD_CANID;
+  cframe->DLC = DASH_CONTROLS_LEFT_CMD_DLC;
+  cframe->IDE = DASH_CONTROLS_LEFT_CMD_IDE;
+  return DASH_CONTROLS_LEFT_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_LEFT_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->DASH_CONTROLS_BUTTON & (0xFFU));
+
+  *_len = DASH_CONTROLS_LEFT_CMD_DLC;
+  *_ide = DASH_CONTROLS_LEFT_CMD_IDE;
+  return DASH_CONTROLS_LEFT_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->DASH_CONTROLS_BUTTON = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DASH_CONTROLS_RIGHT_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DASH_CONTROLS_RIGHT_CMD_pacmod5(&_m->mon1, DASH_CONTROLS_RIGHT_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DASH_CONTROLS_RIGHT_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_RIGHT_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->DASH_CONTROLS_BUTTON & (0xFFU));
+
+  cframe->MsgId = DASH_CONTROLS_RIGHT_CMD_CANID;
+  cframe->DLC = DASH_CONTROLS_RIGHT_CMD_DLC;
+  cframe->IDE = DASH_CONTROLS_RIGHT_CMD_IDE;
+  return DASH_CONTROLS_RIGHT_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_RIGHT_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->DASH_CONTROLS_BUTTON & (0xFFU));
+
+  *_len = DASH_CONTROLS_RIGHT_CMD_DLC;
+  *_ide = DASH_CONTROLS_RIGHT_CMD_IDE;
+  return DASH_CONTROLS_RIGHT_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->HAZARD_LIGHTS_CMD = (_d[1] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HAZARD_LIGHTS_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HAZARD_LIGHTS_CMD_pacmod5(&_m->mon1, HAZARD_LIGHTS_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HAZARD_LIGHTS_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HAZARD_LIGHTS_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->HAZARD_LIGHTS_CMD & (0x01U));
+
+  cframe->MsgId = HAZARD_LIGHTS_CMD_CANID;
+  cframe->DLC = HAZARD_LIGHTS_CMD_DLC;
+  cframe->IDE = HAZARD_LIGHTS_CMD_IDE;
+  return HAZARD_LIGHTS_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HAZARD_LIGHTS_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->HAZARD_LIGHTS_CMD & (0x01U));
+
+  *_len = HAZARD_LIGHTS_CMD_DLC;
+  *_ide = HAZARD_LIGHTS_CMD_IDE;
+  return HAZARD_LIGHTS_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->HEADLIGHT_CMD = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HEADLIGHT_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HEADLIGHT_CMD_pacmod5(&_m->mon1, HEADLIGHT_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HEADLIGHT_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->HEADLIGHT_CMD & (0xFFU));
+
+  cframe->MsgId = HEADLIGHT_CMD_CANID;
+  cframe->DLC = HEADLIGHT_CMD_DLC;
+  cframe->IDE = HEADLIGHT_CMD_IDE;
+  return HEADLIGHT_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->HEADLIGHT_CMD & (0xFFU));
+
+  *_len = HEADLIGHT_CMD_DLC;
+  *_ide = HEADLIGHT_CMD_IDE;
+  return HEADLIGHT_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HORN_CMD_pacmod5(HORN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->HORN_CMD = (_d[1] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HORN_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HORN_CMD_pacmod5(&_m->mon1, HORN_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HORN_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HORN_CMD_pacmod5(HORN_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HORN_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->HORN_CMD & (0x01U));
+
+  cframe->MsgId = HORN_CMD_CANID;
+  cframe->DLC = HORN_CMD_DLC;
+  cframe->IDE = HORN_CMD_IDE;
+  return HORN_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_HORN_CMD_pacmod5(HORN_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HORN_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->HORN_CMD & (0x01U));
+
+  *_len = HORN_CMD_DLC;
+  *_ide = HORN_CMD_IDE;
+  return HORN_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->MEDIA_CONTROLS_CMD = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < MEDIA_CONTROLS_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_MEDIA_CONTROLS_CMD_pacmod5(&_m->mon1, MEDIA_CONTROLS_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return MEDIA_CONTROLS_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < MEDIA_CONTROLS_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->MEDIA_CONTROLS_CMD & (0xFFU));
+
+  cframe->MsgId = MEDIA_CONTROLS_CMD_CANID;
+  cframe->DLC = MEDIA_CONTROLS_CMD_DLC;
+  cframe->IDE = MEDIA_CONTROLS_CMD_IDE;
+  return MEDIA_CONTROLS_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < MEDIA_CONTROLS_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->MEDIA_CONTROLS_CMD & (0xFFU));
+
+  *_len = MEDIA_CONTROLS_CMD_DLC;
+  *_ide = MEDIA_CONTROLS_CMD_IDE;
+  return MEDIA_CONTROLS_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->PARKING_BRAKE_CMD = (_d[1] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < PARKING_BRAKE_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_PARKING_BRAKE_CMD_pacmod5(&_m->mon1, PARKING_BRAKE_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return PARKING_BRAKE_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < PARKING_BRAKE_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->PARKING_BRAKE_CMD & (0x01U));
+
+  cframe->MsgId = PARKING_BRAKE_CMD_CANID;
+  cframe->DLC = PARKING_BRAKE_CMD_DLC;
+  cframe->IDE = PARKING_BRAKE_CMD_IDE;
+  return PARKING_BRAKE_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < PARKING_BRAKE_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->PARKING_BRAKE_CMD & (0x01U));
+
+  *_len = PARKING_BRAKE_CMD_DLC;
+  *_ide = PARKING_BRAKE_CMD_IDE;
+  return PARKING_BRAKE_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->SHIFT_CMD = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SHIFT_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SHIFT_CMD_pacmod5(&_m->mon1, SHIFT_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SHIFT_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->SHIFT_CMD & (0xFFU));
+
+  cframe->MsgId = SHIFT_CMD_CANID;
+  cframe->DLC = SHIFT_CMD_DLC;
+  cframe->IDE = SHIFT_CMD_IDE;
+  return SHIFT_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->SHIFT_CMD & (0xFFU));
+
+  *_len = SHIFT_CMD_DLC;
+  *_ide = SHIFT_CMD_IDE;
+  return SHIFT_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->POSITION_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_phys = (sigfloat_t)(PACMOD5_POSITION_ro_fromS(_m->POSITION_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->ROTATION_RATE_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ROTATION_RATE_phys = (sigfloat_t)(PACMOD5_ROTATION_RATE_ro_fromS(_m->ROTATION_RATE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_CMD_pacmod5(&_m->mon1, STEERING_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_ro = PACMOD5_POSITION_ro_toS(_m->POSITION_phys);
+  _m->ROTATION_RATE_ro = PACMOD5_ROTATION_RATE_ro_toS(_m->ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= ((_m->POSITION_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->POSITION_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->ROTATION_RATE_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->ROTATION_RATE_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_CMD_CANID;
+  cframe->DLC = STEERING_CMD_DLC;
+  cframe->IDE = STEERING_CMD_IDE;
+  return STEERING_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_ro = PACMOD5_POSITION_ro_toS(_m->POSITION_phys);
+  _m->ROTATION_RATE_ro = PACMOD5_ROTATION_RATE_ro_toS(_m->ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= ((_m->POSITION_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->POSITION_ro & (0xFFU));
+  _d[3] |= ((_m->ROTATION_RATE_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->ROTATION_RATE_ro & (0xFFU));
+
+  *_len = STEERING_CMD_DLC;
+  *_ide = STEERING_CMD_IDE;
+  return STEERING_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_CMD_pacmod5(TURN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->TURN_SIGNAL_CMD = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < TURN_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_TURN_CMD_pacmod5(&_m->mon1, TURN_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return TURN_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_TURN_CMD_pacmod5(TURN_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < TURN_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->TURN_SIGNAL_CMD & (0xFFU));
+
+  cframe->MsgId = TURN_CMD_CANID;
+  cframe->DLC = TURN_CMD_DLC;
+  cframe->IDE = TURN_CMD_IDE;
+  return TURN_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_TURN_CMD_pacmod5(TURN_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < TURN_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->TURN_SIGNAL_CMD & (0xFFU));
+
+  *_len = TURN_CMD_DLC;
+  *_ide = TURN_CMD_IDE;
+  return TURN_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->WIPER_CMD = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < WIPER_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_WIPER_CMD_pacmod5(&_m->mon1, WIPER_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return WIPER_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < WIPER_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->WIPER_CMD & (0xFFU));
+
+  cframe->MsgId = WIPER_CMD_CANID;
+  cframe->DLC = WIPER_CMD_DLC;
+  cframe->IDE = WIPER_CMD_IDE;
+  return WIPER_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < WIPER_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->WIPER_CMD & (0xFFU));
+
+  *_len = WIPER_CMD_DLC;
+  *_ide = WIPER_CMD_IDE;
+  return WIPER_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->SPRAYER_CMD = (_d[1] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SPRAYER_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SPRAYER_CMD_pacmod5(&_m->mon1, SPRAYER_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SPRAYER_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SPRAYER_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->SPRAYER_CMD & (0x01U));
+
+  cframe->MsgId = SPRAYER_CMD_CANID;
+  cframe->DLC = SPRAYER_CMD_DLC;
+  cframe->IDE = SPRAYER_CMD_IDE;
+  return SPRAYER_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SPRAYER_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= (_m->SPRAYER_CMD & (0x01U));
+
+  *_len = SPRAYER_CMD_DLC;
+  *_ide = SPRAYER_CMD_IDE;
+  return SPRAYER_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLE = (_d[0] & (0x01U));
+  _m->IGNORE_OVERRIDES = ((_d[0] >> 1) & (0x01U));
+  _m->CLEAR_OVERRIDE = ((_d[0] >> 2) & (0x01U));
+  _m->BRAKE_DECCEL_CMD_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_DECCEL_CMD_phys = (sigfloat_t)(PACMOD5_BRAKE_DECCEL_CMD_ro_fromS(_m->BRAKE_DECCEL_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->XBR_EBI_MODE = (_d[3] & (0x03U));
+  _m->XBR_PRIORITY = ((_d[3] >> 2) & (0x03U));
+  _m->XBR_CONTROL_MODE = ((_d[3] >> 4) & (0x03U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_DECCEL_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_DECCEL_CMD_pacmod5(&_m->mon1, BRAKE_DECCEL_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_DECCEL_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_DECCEL_CMD_ro = PACMOD5_BRAKE_DECCEL_CMD_ro_toS(_m->BRAKE_DECCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  cframe->Data[1] |= ((_m->BRAKE_DECCEL_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->BRAKE_DECCEL_CMD_ro & (0xFFU));
+  cframe->Data[3] |= (_m->XBR_EBI_MODE & (0x03U)) | ((_m->XBR_PRIORITY & (0x03U)) << 2) | ((_m->XBR_CONTROL_MODE & (0x03U)) << 4);
+
+  cframe->MsgId = BRAKE_DECCEL_CMD_CANID;
+  cframe->DLC = BRAKE_DECCEL_CMD_DLC;
+  cframe->IDE = BRAKE_DECCEL_CMD_IDE;
+  return BRAKE_DECCEL_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_DECCEL_CMD_ro = PACMOD5_BRAKE_DECCEL_CMD_ro_toS(_m->BRAKE_DECCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLE & (0x01U)) | ((_m->IGNORE_OVERRIDES & (0x01U)) << 1) | ((_m->CLEAR_OVERRIDE & (0x01U)) << 2);
+  _d[1] |= ((_m->BRAKE_DECCEL_CMD_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->BRAKE_DECCEL_CMD_ro & (0xFFU));
+  _d[3] |= (_m->XBR_EBI_MODE & (0x03U)) | ((_m->XBR_PRIORITY & (0x03U)) << 2) | ((_m->XBR_CONTROL_MODE & (0x03U)) << 4);
+
+  *_len = BRAKE_DECCEL_CMD_DLC;
+  *_ide = BRAKE_DECCEL_CMD_IDE;
+  return BRAKE_DECCEL_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_phys = (sigfloat_t)(PACMOD5_MANUAL_INPUT_ro_fromS(_m->MANUAL_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->COMMANDED_VALUE_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->COMMANDED_VALUE_phys = (sigfloat_t)(PACMOD5_COMMANDED_VALUE_ro_fromS(_m->COMMANDED_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OUTPUT_VALUE_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->OUTPUT_VALUE_phys = (sigfloat_t)(PACMOD5_OUTPUT_VALUE_ro_fromS(_m->OUTPUT_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ACCEL_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ACCEL_RPT_pacmod5(&_m->mon1, ACCEL_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ACCEL_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  cframe->MsgId = ACCEL_RPT_CANID;
+  cframe->DLC = ACCEL_RPT_DLC;
+  cframe->IDE = ACCEL_RPT_IDE;
+  return ACCEL_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  _d[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  _d[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  *_len = ACCEL_RPT_DLC;
+  *_ide = ACCEL_RPT_IDE;
+  return ACCEL_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ACCEL_CMD_LIMIT_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_LIMIT_phys = (sigfloat_t)(PACMOD5_ACCEL_CMD_LIMIT_ro_fromS(_m->ACCEL_CMD_LIMIT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->LIMITED_ACCEL_CMD_ro = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LIMITED_ACCEL_CMD_phys = (sigfloat_t)(PACMOD5_LIMITED_ACCEL_CMD_ro_fromS(_m->LIMITED_ACCEL_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ACCEL_CMD_LIMIT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ACCEL_CMD_LIMIT_RPT_pacmod5(&_m->mon1, ACCEL_CMD_LIMIT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ACCEL_CMD_LIMIT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_CMD_LIMIT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_LIMIT_ro = PACMOD5_ACCEL_CMD_LIMIT_ro_toS(_m->ACCEL_CMD_LIMIT_phys);
+  _m->LIMITED_ACCEL_CMD_ro = PACMOD5_LIMITED_ACCEL_CMD_ro_toS(_m->LIMITED_ACCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->ACCEL_CMD_LIMIT_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->ACCEL_CMD_LIMIT_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->LIMITED_ACCEL_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->LIMITED_ACCEL_CMD_ro & (0xFFU));
+
+  cframe->MsgId = ACCEL_CMD_LIMIT_RPT_CANID;
+  cframe->DLC = ACCEL_CMD_LIMIT_RPT_DLC;
+  cframe->IDE = ACCEL_CMD_LIMIT_RPT_IDE;
+  return ACCEL_CMD_LIMIT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_CMD_LIMIT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ACCEL_CMD_LIMIT_ro = PACMOD5_ACCEL_CMD_LIMIT_ro_toS(_m->ACCEL_CMD_LIMIT_phys);
+  _m->LIMITED_ACCEL_CMD_ro = PACMOD5_LIMITED_ACCEL_CMD_ro_toS(_m->LIMITED_ACCEL_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->ACCEL_CMD_LIMIT_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->ACCEL_CMD_LIMIT_ro & (0xFFU));
+  _d[2] |= ((_m->LIMITED_ACCEL_CMD_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->LIMITED_ACCEL_CMD_ro & (0xFFU));
+
+  *_len = ACCEL_CMD_LIMIT_RPT_DLC;
+  *_ide = ACCEL_CMD_LIMIT_RPT_IDE;
+  return ACCEL_CMD_LIMIT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_phys = (sigfloat_t)(PACMOD5_MANUAL_INPUT_ro_fromS(_m->MANUAL_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->COMMANDED_VALUE_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->COMMANDED_VALUE_phys = (sigfloat_t)(PACMOD5_COMMANDED_VALUE_ro_fromS(_m->COMMANDED_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OUTPUT_VALUE_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->OUTPUT_VALUE_phys = (sigfloat_t)(PACMOD5_OUTPUT_VALUE_ro_fromS(_m->OUTPUT_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_RPT_pacmod5(&_m->mon1, BRAKE_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_RPT_CANID;
+  cframe->DLC = BRAKE_RPT_DLC;
+  cframe->IDE = BRAKE_RPT_IDE;
+  return BRAKE_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  _d[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  _d[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  *_len = BRAKE_RPT_DLC;
+  *_ide = BRAKE_RPT_IDE;
+  return BRAKE_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->BRAKE_CMD_LIMIT_ro = ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_LIMIT_phys = (sigfloat_t)(PACMOD5_BRAKE_CMD_LIMIT_ro_fromS(_m->BRAKE_CMD_LIMIT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->LIMITED_BRAKE_CMD_ro = ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LIMITED_BRAKE_CMD_phys = (sigfloat_t)(PACMOD5_LIMITED_BRAKE_CMD_ro_fromS(_m->LIMITED_BRAKE_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_CMD_LIMIT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_CMD_LIMIT_RPT_pacmod5(&_m->mon1, BRAKE_CMD_LIMIT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_CMD_LIMIT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_CMD_LIMIT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_LIMIT_ro = PACMOD5_BRAKE_CMD_LIMIT_ro_toS(_m->BRAKE_CMD_LIMIT_phys);
+  _m->LIMITED_BRAKE_CMD_ro = PACMOD5_LIMITED_BRAKE_CMD_ro_toS(_m->LIMITED_BRAKE_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->BRAKE_CMD_LIMIT_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->BRAKE_CMD_LIMIT_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->LIMITED_BRAKE_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->LIMITED_BRAKE_CMD_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_CMD_LIMIT_RPT_CANID;
+  cframe->DLC = BRAKE_CMD_LIMIT_RPT_DLC;
+  cframe->IDE = BRAKE_CMD_LIMIT_RPT_IDE;
+  return BRAKE_CMD_LIMIT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_CMD_LIMIT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->BRAKE_CMD_LIMIT_ro = PACMOD5_BRAKE_CMD_LIMIT_ro_toS(_m->BRAKE_CMD_LIMIT_phys);
+  _m->LIMITED_BRAKE_CMD_ro = PACMOD5_LIMITED_BRAKE_CMD_ro_toS(_m->LIMITED_BRAKE_CMD_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->BRAKE_CMD_LIMIT_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->BRAKE_CMD_LIMIT_ro & (0xFFU));
+  _d[2] |= ((_m->LIMITED_BRAKE_CMD_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->LIMITED_BRAKE_CMD_ro & (0xFFU));
+
+  *_len = BRAKE_CMD_LIMIT_RPT_DLC;
+  *_ide = BRAKE_CMD_LIMIT_RPT_IDE;
+  return BRAKE_CMD_LIMIT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < CRUISE_CONTROL_BUTTONS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(&_m->mon1, CRUISE_CONTROL_BUTTONS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return CRUISE_CONTROL_BUTTONS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < CRUISE_CONTROL_BUTTONS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = CRUISE_CONTROL_BUTTONS_RPT_CANID;
+  cframe->DLC = CRUISE_CONTROL_BUTTONS_RPT_DLC;
+  cframe->IDE = CRUISE_CONTROL_BUTTONS_RPT_IDE;
+  return CRUISE_CONTROL_BUTTONS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < CRUISE_CONTROL_BUTTONS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = CRUISE_CONTROL_BUTTONS_RPT_DLC;
+  *_ide = CRUISE_CONTROL_BUTTONS_RPT_IDE;
+  return CRUISE_CONTROL_BUTTONS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DASH_CONTROLS_LEFT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DASH_CONTROLS_LEFT_RPT_pacmod5(&_m->mon1, DASH_CONTROLS_LEFT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DASH_CONTROLS_LEFT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_LEFT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = DASH_CONTROLS_LEFT_RPT_CANID;
+  cframe->DLC = DASH_CONTROLS_LEFT_RPT_DLC;
+  cframe->IDE = DASH_CONTROLS_LEFT_RPT_IDE;
+  return DASH_CONTROLS_LEFT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_LEFT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = DASH_CONTROLS_LEFT_RPT_DLC;
+  *_ide = DASH_CONTROLS_LEFT_RPT_IDE;
+  return DASH_CONTROLS_LEFT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DASH_CONTROLS_RIGHT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DASH_CONTROLS_RIGHT_RPT_pacmod5(&_m->mon1, DASH_CONTROLS_RIGHT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DASH_CONTROLS_RIGHT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_RIGHT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = DASH_CONTROLS_RIGHT_RPT_CANID;
+  cframe->DLC = DASH_CONTROLS_RIGHT_RPT_DLC;
+  cframe->IDE = DASH_CONTROLS_RIGHT_RPT_IDE;
+  return DASH_CONTROLS_RIGHT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DASH_CONTROLS_RIGHT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = DASH_CONTROLS_RIGHT_RPT_DLC;
+  *_ide = DASH_CONTROLS_RIGHT_RPT_IDE;
+  return DASH_CONTROLS_RIGHT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0x01U));
+  _m->COMMANDED_VALUE = (_d[2] & (0x01U));
+  _m->OUTPUT_VALUE = (_d[3] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HAZARD_LIGHTS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HAZARD_LIGHTS_RPT_pacmod5(&_m->mon1, HAZARD_LIGHTS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HAZARD_LIGHTS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HAZARD_LIGHTS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0x01U));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  cframe->MsgId = HAZARD_LIGHTS_RPT_CANID;
+  cframe->DLC = HAZARD_LIGHTS_RPT_DLC;
+  cframe->IDE = HAZARD_LIGHTS_RPT_IDE;
+  return HAZARD_LIGHTS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HAZARD_LIGHTS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0x01U));
+  _d[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  _d[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  *_len = HAZARD_LIGHTS_RPT_DLC;
+  *_ide = HAZARD_LIGHTS_RPT_IDE;
+  return HAZARD_LIGHTS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HEADLIGHT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HEADLIGHT_RPT_pacmod5(&_m->mon1, HEADLIGHT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HEADLIGHT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = HEADLIGHT_RPT_CANID;
+  cframe->DLC = HEADLIGHT_RPT_DLC;
+  cframe->IDE = HEADLIGHT_RPT_IDE;
+  return HEADLIGHT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = HEADLIGHT_RPT_DLC;
+  *_ide = HEADLIGHT_RPT_IDE;
+  return HEADLIGHT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HORN_RPT_pacmod5(HORN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HORN_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HORN_RPT_pacmod5(&_m->mon1, HORN_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HORN_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HORN_RPT_pacmod5(HORN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HORN_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = HORN_RPT_CANID;
+  cframe->DLC = HORN_RPT_DLC;
+  cframe->IDE = HORN_RPT_IDE;
+  return HORN_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_HORN_RPT_pacmod5(HORN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HORN_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = HORN_RPT_DLC;
+  *_ide = HORN_RPT_IDE;
+  return HORN_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < MEDIA_CONTROLS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_MEDIA_CONTROLS_RPT_pacmod5(&_m->mon1, MEDIA_CONTROLS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return MEDIA_CONTROLS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < MEDIA_CONTROLS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = MEDIA_CONTROLS_RPT_CANID;
+  cframe->DLC = MEDIA_CONTROLS_RPT_DLC;
+  cframe->IDE = MEDIA_CONTROLS_RPT_IDE;
+  return MEDIA_CONTROLS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < MEDIA_CONTROLS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = MEDIA_CONTROLS_RPT_DLC;
+  *_ide = MEDIA_CONTROLS_RPT_IDE;
+  return MEDIA_CONTROLS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0x01U));
+  _m->COMMANDED_VALUE = (_d[2] & (0x01U));
+  _m->OUTPUT_VALUE = (_d[3] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < PARKING_BRAKE_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_PARKING_BRAKE_RPT_pacmod5(&_m->mon1, PARKING_BRAKE_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return PARKING_BRAKE_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < PARKING_BRAKE_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0x01U));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  cframe->MsgId = PARKING_BRAKE_RPT_CANID;
+  cframe->DLC = PARKING_BRAKE_RPT_DLC;
+  cframe->IDE = PARKING_BRAKE_RPT_IDE;
+  return PARKING_BRAKE_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < PARKING_BRAKE_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0x01U));
+  _d[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  _d[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  *_len = PARKING_BRAKE_RPT_DLC;
+  *_ide = PARKING_BRAKE_RPT_IDE;
+  return PARKING_BRAKE_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SHIFT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SHIFT_RPT_pacmod5(&_m->mon1, SHIFT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SHIFT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = SHIFT_RPT_CANID;
+  cframe->DLC = SHIFT_RPT_DLC;
+  cframe->IDE = SHIFT_RPT_IDE;
+  return SHIFT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = SHIFT_RPT_DLC;
+  *_ide = SHIFT_RPT_IDE;
+  return SHIFT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_phys = (sigfloat_t)(PACMOD5_MANUAL_INPUT_ro_fromS(_m->MANUAL_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->COMMANDED_VALUE_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->COMMANDED_VALUE_phys = (sigfloat_t)(PACMOD5_COMMANDED_VALUE_ro_fromS(_m->COMMANDED_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OUTPUT_VALUE_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->OUTPUT_VALUE_phys = (sigfloat_t)(PACMOD5_OUTPUT_VALUE_ro_fromS(_m->OUTPUT_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_RPT_pacmod5(&_m->mon1, STEERING_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_RPT_CANID;
+  cframe->DLC = STEERING_RPT_DLC;
+  cframe->IDE = STEERING_RPT_IDE;
+  return STEERING_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  _d[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  _d[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  *_len = STEERING_RPT_DLC;
+  *_ide = STEERING_RPT_IDE;
+  return STEERING_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->POSITION_CMD_LIMIT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_CMD_LIMIT_phys = (sigfloat_t)(PACMOD5_POSITION_CMD_LIMIT_ro_fromS(_m->POSITION_CMD_LIMIT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->LIMITED_POSITION_CMD_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LIMITED_POSITION_CMD_phys = (sigfloat_t)(PACMOD5_LIMITED_POSITION_CMD_ro_fromS(_m->LIMITED_POSITION_CMD_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->ROTATION_RATE_CMD_LIMIT_ro = ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ROTATION_RATE_CMD_LIMIT_phys = (sigfloat_t)(PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_fromS(_m->ROTATION_RATE_CMD_LIMIT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->LIMITED_ROTATION_RATE_ro = ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LIMITED_ROTATION_RATE_phys = (sigfloat_t)(PACMOD5_LIMITED_ROTATION_RATE_ro_fromS(_m->LIMITED_ROTATION_RATE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_CMD_LIMIT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_CMD_LIMIT_RPT_pacmod5(&_m->mon1, STEERING_CMD_LIMIT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_CMD_LIMIT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_CMD_LIMIT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_CMD_LIMIT_ro = PACMOD5_POSITION_CMD_LIMIT_ro_toS(_m->POSITION_CMD_LIMIT_phys);
+  _m->LIMITED_POSITION_CMD_ro = PACMOD5_LIMITED_POSITION_CMD_ro_toS(_m->LIMITED_POSITION_CMD_phys);
+  _m->ROTATION_RATE_CMD_LIMIT_ro = PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_toS(_m->ROTATION_RATE_CMD_LIMIT_phys);
+  _m->LIMITED_ROTATION_RATE_ro = PACMOD5_LIMITED_ROTATION_RATE_ro_toS(_m->LIMITED_ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->POSITION_CMD_LIMIT_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->POSITION_CMD_LIMIT_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->LIMITED_POSITION_CMD_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->LIMITED_POSITION_CMD_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->ROTATION_RATE_CMD_LIMIT_ro >> 8) & (0xFFU));
+  cframe->Data[5] |= (_m->ROTATION_RATE_CMD_LIMIT_ro & (0xFFU));
+  cframe->Data[6] |= ((_m->LIMITED_ROTATION_RATE_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->LIMITED_ROTATION_RATE_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_CMD_LIMIT_RPT_CANID;
+  cframe->DLC = STEERING_CMD_LIMIT_RPT_DLC;
+  cframe->IDE = STEERING_CMD_LIMIT_RPT_IDE;
+  return STEERING_CMD_LIMIT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_CMD_LIMIT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->POSITION_CMD_LIMIT_ro = PACMOD5_POSITION_CMD_LIMIT_ro_toS(_m->POSITION_CMD_LIMIT_phys);
+  _m->LIMITED_POSITION_CMD_ro = PACMOD5_LIMITED_POSITION_CMD_ro_toS(_m->LIMITED_POSITION_CMD_phys);
+  _m->ROTATION_RATE_CMD_LIMIT_ro = PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_toS(_m->ROTATION_RATE_CMD_LIMIT_phys);
+  _m->LIMITED_ROTATION_RATE_ro = PACMOD5_LIMITED_ROTATION_RATE_ro_toS(_m->LIMITED_ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->POSITION_CMD_LIMIT_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->POSITION_CMD_LIMIT_ro & (0xFFU));
+  _d[2] |= ((_m->LIMITED_POSITION_CMD_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->LIMITED_POSITION_CMD_ro & (0xFFU));
+  _d[4] |= ((_m->ROTATION_RATE_CMD_LIMIT_ro >> 8) & (0xFFU));
+  _d[5] |= (_m->ROTATION_RATE_CMD_LIMIT_ro & (0xFFU));
+  _d[6] |= ((_m->LIMITED_ROTATION_RATE_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->LIMITED_ROTATION_RATE_ro & (0xFFU));
+
+  *_len = STEERING_CMD_LIMIT_RPT_DLC;
+  *_ide = STEERING_CMD_LIMIT_RPT_IDE;
+  return STEERING_CMD_LIMIT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_RPT_pacmod5(TURN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < TURN_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_TURN_RPT_pacmod5(&_m->mon1, TURN_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return TURN_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_TURN_RPT_pacmod5(TURN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < TURN_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = TURN_RPT_CANID;
+  cframe->DLC = TURN_RPT_DLC;
+  cframe->IDE = TURN_RPT_IDE;
+  return TURN_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_TURN_RPT_pacmod5(TURN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < TURN_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = TURN_RPT_DLC;
+  *_ide = TURN_RPT_IDE;
+  return TURN_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0xFFU));
+  _m->COMMANDED_VALUE = (_d[2] & (0xFFU));
+  _m->OUTPUT_VALUE = (_d[3] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < WIPER_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_WIPER_RPT_pacmod5(&_m->mon1, WIPER_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return WIPER_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < WIPER_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  cframe->MsgId = WIPER_RPT_CANID;
+  cframe->DLC = WIPER_RPT_DLC;
+  cframe->IDE = WIPER_RPT_IDE;
+  return WIPER_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < WIPER_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0xFFU));
+  _d[2] |= (_m->COMMANDED_VALUE & (0xFFU));
+  _d[3] |= (_m->OUTPUT_VALUE & (0xFFU));
+
+  *_len = WIPER_RPT_DLC;
+  *_ide = WIPER_RPT_IDE;
+  return WIPER_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT = (_d[1] & (0x01U));
+  _m->COMMANDED_VALUE = (_d[2] & (0x01U));
+  _m->OUTPUT_VALUE = (_d[3] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SPRAYER_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SPRAYER_RPT_pacmod5(&_m->mon1, SPRAYER_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SPRAYER_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SPRAYER_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->MANUAL_INPUT & (0x01U));
+  cframe->Data[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  cframe->Data[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  cframe->MsgId = SPRAYER_RPT_CANID;
+  cframe->DLC = SPRAYER_RPT_DLC;
+  cframe->IDE = SPRAYER_RPT_IDE;
+  return SPRAYER_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SPRAYER_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->MANUAL_INPUT & (0x01U));
+  _d[2] |= (_m->COMMANDED_VALUE & (0x01U));
+  _d[3] |= (_m->OUTPUT_VALUE & (0x01U));
+
+  *_len = SPRAYER_RPT_DLC;
+  *_ide = SPRAYER_RPT_IDE;
+  return SPRAYER_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENABLED = (_d[0] & (0x01U));
+  _m->OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->COMMAND_OUTPUT_FAULT = ((_d[0] >> 2) & (0x01U));
+  _m->INPUT_OUTPUT_FAULT = ((_d[0] >> 3) & (0x01U));
+  _m->OUTPUT_REPORTED_FAULT = ((_d[0] >> 4) & (0x01U));
+  _m->PACMOD_FAULT = ((_d[0] >> 5) & (0x01U));
+  _m->VEHICLE_FAULT = ((_d[0] >> 6) & (0x01U));
+  _m->COMMAND_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->MANUAL_INPUT_ro = ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_phys = (sigfloat_t)(PACMOD5_MANUAL_INPUT_ro_fromS(_m->MANUAL_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->COMMANDED_VALUE_ro = ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->COMMANDED_VALUE_phys = (sigfloat_t)(PACMOD5_COMMANDED_VALUE_ro_fromS(_m->COMMANDED_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OUTPUT_VALUE_ro = ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->OUTPUT_VALUE_phys = (sigfloat_t)(PACMOD5_OUTPUT_VALUE_ro_fromS(_m->OUTPUT_VALUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_DECCEL_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_DECCEL_RPT_pacmod5(&_m->mon1, BRAKE_DECCEL_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_DECCEL_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_DECCEL_RPT_CANID;
+  cframe->DLC = BRAKE_DECCEL_RPT_DLC;
+  cframe->IDE = BRAKE_DECCEL_RPT_IDE;
+  return BRAKE_DECCEL_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MANUAL_INPUT_ro = PACMOD5_MANUAL_INPUT_ro_toS(_m->MANUAL_INPUT_phys);
+  _m->COMMANDED_VALUE_ro = PACMOD5_COMMANDED_VALUE_ro_toS(_m->COMMANDED_VALUE_phys);
+  _m->OUTPUT_VALUE_ro = PACMOD5_OUTPUT_VALUE_ro_toS(_m->OUTPUT_VALUE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->ENABLED & (0x01U)) | ((_m->OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->PACMOD_FAULT & (0x01U)) << 5) | ((_m->VEHICLE_FAULT & (0x01U)) << 6) | ((_m->COMMAND_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= ((_m->MANUAL_INPUT_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->MANUAL_INPUT_ro & (0xFFU));
+  _d[3] |= ((_m->COMMANDED_VALUE_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->COMMANDED_VALUE_ro & (0xFFU));
+  _d[5] |= ((_m->OUTPUT_VALUE_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->OUTPUT_VALUE_ro & (0xFFU));
+
+  *_len = BRAKE_DECCEL_RPT_DLC;
+  *_ide = BRAKE_DECCEL_RPT_IDE;
+  return BRAKE_DECCEL_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->RAW_PEDAL_POS_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_PEDAL_POS_phys = (sigfloat_t)(PACMOD5_RAW_PEDAL_POS_ro_fromS(_m->RAW_PEDAL_POS_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->RAW_PEDAL_FORCE_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_PEDAL_FORCE_phys = (sigfloat_t)(PACMOD5_RAW_PEDAL_FORCE_ro_fromS(_m->RAW_PEDAL_FORCE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OPERATOR_INTERACTION = (_d[4] & (0x01U));
+  _m->RAW_PEDAL_POS_AVAIL = (_d[5] & (0x01U));
+  _m->RAW_PEDAL_FORCE_AVAIL = ((_d[5] >> 1) & (0x01U));
+  _m->OPERATOR_INTERACTION_AVAIL = ((_d[5] >> 2) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ACCEL_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ACCEL_AUX_RPT_pacmod5(&_m->mon1, ACCEL_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ACCEL_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_PEDAL_POS_ro = PACMOD5_RAW_PEDAL_POS_ro_toS(_m->RAW_PEDAL_POS_phys);
+  _m->RAW_PEDAL_FORCE_ro = PACMOD5_RAW_PEDAL_FORCE_ro_toS(_m->RAW_PEDAL_FORCE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->RAW_PEDAL_POS_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->RAW_PEDAL_POS_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->RAW_PEDAL_FORCE_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->RAW_PEDAL_FORCE_ro & (0xFFU));
+  cframe->Data[4] |= (_m->OPERATOR_INTERACTION & (0x01U));
+  cframe->Data[5] |= (_m->RAW_PEDAL_POS_AVAIL & (0x01U)) | ((_m->RAW_PEDAL_FORCE_AVAIL & (0x01U)) << 1) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 2);
+
+  cframe->MsgId = ACCEL_AUX_RPT_CANID;
+  cframe->DLC = ACCEL_AUX_RPT_DLC;
+  cframe->IDE = ACCEL_AUX_RPT_IDE;
+  return ACCEL_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ACCEL_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_PEDAL_POS_ro = PACMOD5_RAW_PEDAL_POS_ro_toS(_m->RAW_PEDAL_POS_phys);
+  _m->RAW_PEDAL_FORCE_ro = PACMOD5_RAW_PEDAL_FORCE_ro_toS(_m->RAW_PEDAL_FORCE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->RAW_PEDAL_POS_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->RAW_PEDAL_POS_ro & (0xFFU));
+  _d[2] |= ((_m->RAW_PEDAL_FORCE_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->RAW_PEDAL_FORCE_ro & (0xFFU));
+  _d[4] |= (_m->OPERATOR_INTERACTION & (0x01U));
+  _d[5] |= (_m->RAW_PEDAL_POS_AVAIL & (0x01U)) | ((_m->RAW_PEDAL_FORCE_AVAIL & (0x01U)) << 1) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 2);
+
+  *_len = ACCEL_AUX_RPT_DLC;
+  *_ide = ACCEL_AUX_RPT_IDE;
+  return ACCEL_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->RAW_PEDAL_POS = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->RAW_PEDAL_FORCE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->RAW_BRAKE_PRESSURE = __ext_sig__(( ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU)) ), 16);
+  _m->OPERATOR_INTERACTION = (_d[6] & (0x01U));
+  _m->BRAKE_ON_OFF = ((_d[6] >> 1) & (0x01U));
+  _m->RAW_PEDAL_POS_AVAIL = (_d[7] & (0x01U));
+  _m->RAW_PEDAL_FORCE_AVAIL = ((_d[7] >> 1) & (0x01U));
+  _m->RAW_BRAKE_PRESSURE_AVAIL = ((_d[7] >> 2) & (0x01U));
+  _m->OPERATOR_INTERACTION_AVAIL = ((_d[7] >> 3) & (0x01U));
+  _m->BRAKE_ON_OFF_AVAIL = ((_d[7] >> 4) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_AUX_RPT_pacmod5(&_m->mon1, BRAKE_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= ((_m->RAW_PEDAL_POS >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->RAW_PEDAL_POS & (0xFFU));
+  cframe->Data[2] |= ((_m->RAW_PEDAL_FORCE >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->RAW_PEDAL_FORCE & (0xFFU));
+  cframe->Data[4] |= ((_m->RAW_BRAKE_PRESSURE >> 8) & (0xFFU));
+  cframe->Data[5] |= (_m->RAW_BRAKE_PRESSURE & (0xFFU));
+  cframe->Data[6] |= (_m->OPERATOR_INTERACTION & (0x01U)) | ((_m->BRAKE_ON_OFF & (0x01U)) << 1);
+  cframe->Data[7] |= (_m->RAW_PEDAL_POS_AVAIL & (0x01U)) | ((_m->RAW_PEDAL_FORCE_AVAIL & (0x01U)) << 1) | ((_m->RAW_BRAKE_PRESSURE_AVAIL & (0x01U)) << 2) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 3) | ((_m->BRAKE_ON_OFF_AVAIL & (0x01U)) << 4);
+
+  cframe->MsgId = BRAKE_AUX_RPT_CANID;
+  cframe->DLC = BRAKE_AUX_RPT_DLC;
+  cframe->IDE = BRAKE_AUX_RPT_IDE;
+  return BRAKE_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= ((_m->RAW_PEDAL_POS >> 8) & (0xFFU));
+  _d[1] |= (_m->RAW_PEDAL_POS & (0xFFU));
+  _d[2] |= ((_m->RAW_PEDAL_FORCE >> 8) & (0xFFU));
+  _d[3] |= (_m->RAW_PEDAL_FORCE & (0xFFU));
+  _d[4] |= ((_m->RAW_BRAKE_PRESSURE >> 8) & (0xFFU));
+  _d[5] |= (_m->RAW_BRAKE_PRESSURE & (0xFFU));
+  _d[6] |= (_m->OPERATOR_INTERACTION & (0x01U)) | ((_m->BRAKE_ON_OFF & (0x01U)) << 1);
+  _d[7] |= (_m->RAW_PEDAL_POS_AVAIL & (0x01U)) | ((_m->RAW_PEDAL_FORCE_AVAIL & (0x01U)) << 1) | ((_m->RAW_BRAKE_PRESSURE_AVAIL & (0x01U)) << 2) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 3) | ((_m->BRAKE_ON_OFF_AVAIL & (0x01U)) << 4);
+
+  *_len = BRAKE_AUX_RPT_DLC;
+  *_ide = BRAKE_AUX_RPT_IDE;
+  return BRAKE_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->HEADLIGHTS_ON = (_d[0] & (0x01U));
+  _m->HEADLIGHTS_ON_BRIGHT = ((_d[0] >> 1) & (0x01U));
+  _m->FOG_LIGHTS_ON = ((_d[0] >> 2) & (0x01U));
+  _m->HEADLIGHTS_MODE = (_d[1] & (0xFFU));
+  _m->HEADLIGHTS_ON_AVAIL = (_d[2] & (0x01U));
+  _m->HEADLIGHTS_ON_BRIGHT_AVAIL = ((_d[2] >> 1) & (0x01U));
+  _m->FOG_LIGHTS_ON_AVAIL = ((_d[2] >> 2) & (0x01U));
+  _m->HEADLIGHTS_MODE_AVAIL = ((_d[2] >> 3) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < HEADLIGHT_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_HEADLIGHT_AUX_RPT_pacmod5(&_m->mon1, HEADLIGHT_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return HEADLIGHT_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->HEADLIGHTS_ON & (0x01U)) | ((_m->HEADLIGHTS_ON_BRIGHT & (0x01U)) << 1) | ((_m->FOG_LIGHTS_ON & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->HEADLIGHTS_MODE & (0xFFU));
+  cframe->Data[2] |= (_m->HEADLIGHTS_ON_AVAIL & (0x01U)) | ((_m->HEADLIGHTS_ON_BRIGHT_AVAIL & (0x01U)) << 1) | ((_m->FOG_LIGHTS_ON_AVAIL & (0x01U)) << 2) | ((_m->HEADLIGHTS_MODE_AVAIL & (0x01U)) << 3);
+
+  cframe->MsgId = HEADLIGHT_AUX_RPT_CANID;
+  cframe->DLC = HEADLIGHT_AUX_RPT_DLC;
+  cframe->IDE = HEADLIGHT_AUX_RPT_IDE;
+  return HEADLIGHT_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < HEADLIGHT_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->HEADLIGHTS_ON & (0x01U)) | ((_m->HEADLIGHTS_ON_BRIGHT & (0x01U)) << 1) | ((_m->FOG_LIGHTS_ON & (0x01U)) << 2);
+  _d[1] |= (_m->HEADLIGHTS_MODE & (0xFFU));
+  _d[2] |= (_m->HEADLIGHTS_ON_AVAIL & (0x01U)) | ((_m->HEADLIGHTS_ON_BRIGHT_AVAIL & (0x01U)) << 1) | ((_m->FOG_LIGHTS_ON_AVAIL & (0x01U)) << 2) | ((_m->HEADLIGHTS_MODE_AVAIL & (0x01U)) << 3);
+
+  *_len = HEADLIGHT_AUX_RPT_DLC;
+  *_ide = HEADLIGHT_AUX_RPT_IDE;
+  return HEADLIGHT_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->BETWEEN_GEARS = (_d[0] & (0x01U));
+  _m->STAY_IN_NEUTRAL_MODE = ((_d[0] >> 1) & (0x01U));
+  _m->BRAKE_INTERLOCK_ACTIVE = ((_d[0] >> 2) & (0x01U));
+  _m->SPEED_INTERLOCK_ACTIVE = ((_d[0] >> 3) & (0x01U));
+  _m->BETWEEN_GEARS_AVAIL = (_d[1] & (0x01U));
+  _m->STAY_IN_NEUTRAL_MODE_AVAIL = ((_d[1] >> 1) & (0x01U));
+  _m->BRAKE_INTERLOCK_ACTIVE_AVAIL = ((_d[1] >> 2) & (0x01U));
+  _m->SPEED_INTERLOCK_ACTIVE_AVAIL = ((_d[1] >> 3) & (0x01U));
+  _m->WRITE_TO_CONFIG = (_d[7] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SHIFT_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SHIFT_AUX_RPT_pacmod5(&_m->mon1, SHIFT_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SHIFT_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->BETWEEN_GEARS & (0x01U)) | ((_m->STAY_IN_NEUTRAL_MODE & (0x01U)) << 1) | ((_m->BRAKE_INTERLOCK_ACTIVE & (0x01U)) << 2) | ((_m->SPEED_INTERLOCK_ACTIVE & (0x01U)) << 3);
+  cframe->Data[1] |= (_m->BETWEEN_GEARS_AVAIL & (0x01U)) | ((_m->STAY_IN_NEUTRAL_MODE_AVAIL & (0x01U)) << 1) | ((_m->BRAKE_INTERLOCK_ACTIVE_AVAIL & (0x01U)) << 2) | ((_m->SPEED_INTERLOCK_ACTIVE_AVAIL & (0x01U)) << 3);
+  cframe->Data[7] |= (_m->WRITE_TO_CONFIG & (0x01U));
+
+  cframe->MsgId = SHIFT_AUX_RPT_CANID;
+  cframe->DLC = SHIFT_AUX_RPT_DLC;
+  cframe->IDE = SHIFT_AUX_RPT_IDE;
+  return SHIFT_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SHIFT_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->BETWEEN_GEARS & (0x01U)) | ((_m->STAY_IN_NEUTRAL_MODE & (0x01U)) << 1) | ((_m->BRAKE_INTERLOCK_ACTIVE & (0x01U)) << 2) | ((_m->SPEED_INTERLOCK_ACTIVE & (0x01U)) << 3);
+  _d[1] |= (_m->BETWEEN_GEARS_AVAIL & (0x01U)) | ((_m->STAY_IN_NEUTRAL_MODE_AVAIL & (0x01U)) << 1) | ((_m->BRAKE_INTERLOCK_ACTIVE_AVAIL & (0x01U)) << 2) | ((_m->SPEED_INTERLOCK_ACTIVE_AVAIL & (0x01U)) << 3);
+  _d[7] |= (_m->WRITE_TO_CONFIG & (0x01U));
+
+  *_len = SHIFT_AUX_RPT_DLC;
+  *_ide = SHIFT_AUX_RPT_IDE;
+  return SHIFT_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->RAW_POSITION_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_POSITION_phys = (sigfloat_t)(PACMOD5_RAW_POSITION_ro_fromS(_m->RAW_POSITION_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->RAW_TORQUE_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_TORQUE_phys = (sigfloat_t)(PACMOD5_RAW_TORQUE_ro_fromS(_m->RAW_TORQUE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->ROTATION_RATE_ro = ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ROTATION_RATE_phys = (sigfloat_t)(PACMOD5_ROTATION_RATE_ro_fromS(_m->ROTATION_RATE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->OPERATOR_INTERACTION = (_d[6] & (0x01U));
+  _m->RAW_POSITION_AVAIL = (_d[7] & (0x01U));
+  _m->RAW_TORQUE_AVAIL = ((_d[7] >> 1) & (0x01U));
+  _m->ROTATION_RATE_AVAIL = ((_d[7] >> 2) & (0x01U));
+  _m->OPERATOR_INTERACTION_AVAIL = ((_d[7] >> 3) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_AUX_RPT_pacmod5(&_m->mon1, STEERING_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_POSITION_ro = PACMOD5_RAW_POSITION_ro_toS(_m->RAW_POSITION_phys);
+  _m->RAW_TORQUE_ro = PACMOD5_RAW_TORQUE_ro_toS(_m->RAW_TORQUE_phys);
+  _m->ROTATION_RATE_ro = PACMOD5_ROTATION_RATE_ro_toS(_m->ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->RAW_POSITION_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->RAW_POSITION_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->RAW_TORQUE_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->RAW_TORQUE_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->ROTATION_RATE_ro >> 8) & (0xFFU));
+  cframe->Data[5] |= (_m->ROTATION_RATE_ro & (0xFFU));
+  cframe->Data[6] |= (_m->OPERATOR_INTERACTION & (0x01U));
+  cframe->Data[7] |= (_m->RAW_POSITION_AVAIL & (0x01U)) | ((_m->RAW_TORQUE_AVAIL & (0x01U)) << 1) | ((_m->ROTATION_RATE_AVAIL & (0x01U)) << 2) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 3);
+
+  cframe->MsgId = STEERING_AUX_RPT_CANID;
+  cframe->DLC = STEERING_AUX_RPT_DLC;
+  cframe->IDE = STEERING_AUX_RPT_IDE;
+  return STEERING_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->RAW_POSITION_ro = PACMOD5_RAW_POSITION_ro_toS(_m->RAW_POSITION_phys);
+  _m->RAW_TORQUE_ro = PACMOD5_RAW_TORQUE_ro_toS(_m->RAW_TORQUE_phys);
+  _m->ROTATION_RATE_ro = PACMOD5_ROTATION_RATE_ro_toS(_m->ROTATION_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->RAW_POSITION_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->RAW_POSITION_ro & (0xFFU));
+  _d[2] |= ((_m->RAW_TORQUE_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->RAW_TORQUE_ro & (0xFFU));
+  _d[4] |= ((_m->ROTATION_RATE_ro >> 8) & (0xFFU));
+  _d[5] |= (_m->ROTATION_RATE_ro & (0xFFU));
+  _d[6] |= (_m->OPERATOR_INTERACTION & (0x01U));
+  _d[7] |= (_m->RAW_POSITION_AVAIL & (0x01U)) | ((_m->RAW_TORQUE_AVAIL & (0x01U)) << 1) | ((_m->ROTATION_RATE_AVAIL & (0x01U)) << 2) | ((_m->OPERATOR_INTERACTION_AVAIL & (0x01U)) << 3);
+
+  *_len = STEERING_AUX_RPT_DLC;
+  *_ide = STEERING_AUX_RPT_IDE;
+  return STEERING_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->DRIVER_BLINKER_BULB_ON = (_d[0] & (0x01U));
+  _m->PASS_BLINKER_BULB_ON = ((_d[0] >> 1) & (0x01U));
+  _m->DRIVER_BLINKER_BULB_ON_AVAIL = (_d[1] & (0x01U));
+  _m->PASS_BLINKER_BULB_ON_AVAIL = ((_d[1] >> 1) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < TURN_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_TURN_AUX_RPT_pacmod5(&_m->mon1, TURN_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return TURN_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < TURN_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->DRIVER_BLINKER_BULB_ON & (0x01U)) | ((_m->PASS_BLINKER_BULB_ON & (0x01U)) << 1);
+  cframe->Data[1] |= (_m->DRIVER_BLINKER_BULB_ON_AVAIL & (0x01U)) | ((_m->PASS_BLINKER_BULB_ON_AVAIL & (0x01U)) << 1);
+
+  cframe->MsgId = TURN_AUX_RPT_CANID;
+  cframe->DLC = TURN_AUX_RPT_DLC;
+  cframe->IDE = TURN_AUX_RPT_IDE;
+  return TURN_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < TURN_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->DRIVER_BLINKER_BULB_ON & (0x01U)) | ((_m->PASS_BLINKER_BULB_ON & (0x01U)) << 1);
+  _d[1] |= (_m->DRIVER_BLINKER_BULB_ON_AVAIL & (0x01U)) | ((_m->PASS_BLINKER_BULB_ON_AVAIL & (0x01U)) << 1);
+
+  *_len = TURN_AUX_RPT_DLC;
+  *_ide = TURN_AUX_RPT_IDE;
+  return TURN_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->FRONT_WIPING = (_d[0] & (0x01U));
+  _m->FRONT_SPRAYING = ((_d[0] >> 1) & (0x01U));
+  _m->REAR_WIPING = ((_d[0] >> 2) & (0x01U));
+  _m->REAR_SPRAYING = ((_d[0] >> 3) & (0x01U));
+  _m->SPRAY_NEAR_EMPTY = ((_d[0] >> 4) & (0x01U));
+  _m->SPRAY_EMPTY = ((_d[0] >> 5) & (0x01U));
+  _m->FRONT_WIPING_AVAIL = (_d[1] & (0x01U));
+  _m->FRONT_SPRAYING_AVAIL = ((_d[1] >> 1) & (0x01U));
+  _m->REAR_WIPING_AVAIL = ((_d[1] >> 2) & (0x01U));
+  _m->REAR_SPRAYING_AVAIL = ((_d[1] >> 3) & (0x01U));
+  _m->SPRAY_NEAR_EMPTY_AVAIL = ((_d[1] >> 4) & (0x01U));
+  _m->SPRAY_EMPTY_AVAIL = ((_d[1] >> 5) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < WIPER_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_WIPER_AUX_RPT_pacmod5(&_m->mon1, WIPER_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return WIPER_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < WIPER_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->FRONT_WIPING & (0x01U)) | ((_m->FRONT_SPRAYING & (0x01U)) << 1) | ((_m->REAR_WIPING & (0x01U)) << 2) | ((_m->REAR_SPRAYING & (0x01U)) << 3) | ((_m->SPRAY_NEAR_EMPTY & (0x01U)) << 4) | ((_m->SPRAY_EMPTY & (0x01U)) << 5);
+  cframe->Data[1] |= (_m->FRONT_WIPING_AVAIL & (0x01U)) | ((_m->FRONT_SPRAYING_AVAIL & (0x01U)) << 1) | ((_m->REAR_WIPING_AVAIL & (0x01U)) << 2) | ((_m->REAR_SPRAYING_AVAIL & (0x01U)) << 3) | ((_m->SPRAY_NEAR_EMPTY_AVAIL & (0x01U)) << 4) | ((_m->SPRAY_EMPTY_AVAIL & (0x01U)) << 5);
+
+  cframe->MsgId = WIPER_AUX_RPT_CANID;
+  cframe->DLC = WIPER_AUX_RPT_DLC;
+  cframe->IDE = WIPER_AUX_RPT_IDE;
+  return WIPER_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < WIPER_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->FRONT_WIPING & (0x01U)) | ((_m->FRONT_SPRAYING & (0x01U)) << 1) | ((_m->REAR_WIPING & (0x01U)) << 2) | ((_m->REAR_SPRAYING & (0x01U)) << 3) | ((_m->SPRAY_NEAR_EMPTY & (0x01U)) << 4) | ((_m->SPRAY_EMPTY & (0x01U)) << 5);
+  _d[1] |= (_m->FRONT_WIPING_AVAIL & (0x01U)) | ((_m->FRONT_SPRAYING_AVAIL & (0x01U)) << 1) | ((_m->REAR_WIPING_AVAIL & (0x01U)) << 2) | ((_m->REAR_SPRAYING_AVAIL & (0x01U)) << 3) | ((_m->SPRAY_NEAR_EMPTY_AVAIL & (0x01U)) << 4) | ((_m->SPRAY_EMPTY_AVAIL & (0x01U)) << 5);
+
+  *_len = WIPER_AUX_RPT_DLC;
+  *_ide = WIPER_AUX_RPT_IDE;
+  return WIPER_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->XBR_ACTIVE_CONTROL_MODE = (_d[0] & (0x0FU));
+  _m->XBR_SYSTEM_STATE = ((_d[0] >> 4) & (0x03U));
+  _m->FOUNDATION_BRAKE_USE = ((_d[0] >> 6) & (0x03U));
+  _m->HILL_HOLDER_MODE = (_d[1] & (0x07U));
+  _m->XBR_ACTIVE_CONTROL_MODE_AVAIL = (_d[2] & (0x01U));
+  _m->XBR_SYSTEM_STATE_AVAIL = ((_d[2] >> 1) & (0x01U));
+  _m->FOUNDATION_BRAKE_USE_AVAIL = ((_d[2] >> 2) & (0x01U));
+  _m->HILL_HOLDER_MODE_AVAIL = ((_d[2] >> 3) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_DECCEL_AUX_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_DECCEL_AUX_RPT_pacmod5(&_m->mon1, BRAKE_DECCEL_AUX_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_DECCEL_AUX_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_AUX_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->XBR_ACTIVE_CONTROL_MODE & (0x0FU)) | ((_m->XBR_SYSTEM_STATE & (0x03U)) << 4) | ((_m->FOUNDATION_BRAKE_USE & (0x03U)) << 6);
+  cframe->Data[1] |= (_m->HILL_HOLDER_MODE & (0x07U));
+  cframe->Data[2] |= (_m->XBR_ACTIVE_CONTROL_MODE_AVAIL & (0x01U)) | ((_m->XBR_SYSTEM_STATE_AVAIL & (0x01U)) << 1) | ((_m->FOUNDATION_BRAKE_USE_AVAIL & (0x01U)) << 2) | ((_m->HILL_HOLDER_MODE_AVAIL & (0x01U)) << 3);
+
+  cframe->MsgId = BRAKE_DECCEL_AUX_RPT_CANID;
+  cframe->DLC = BRAKE_DECCEL_AUX_RPT_DLC;
+  cframe->IDE = BRAKE_DECCEL_AUX_RPT_IDE;
+  return BRAKE_DECCEL_AUX_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_DECCEL_AUX_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->XBR_ACTIVE_CONTROL_MODE & (0x0FU)) | ((_m->XBR_SYSTEM_STATE & (0x03U)) << 4) | ((_m->FOUNDATION_BRAKE_USE & (0x03U)) << 6);
+  _d[1] |= (_m->HILL_HOLDER_MODE & (0x07U));
+  _d[2] |= (_m->XBR_ACTIVE_CONTROL_MODE_AVAIL & (0x01U)) | ((_m->XBR_SYSTEM_STATE_AVAIL & (0x01U)) << 1) | ((_m->FOUNDATION_BRAKE_USE_AVAIL & (0x01U)) << 2) | ((_m->HILL_HOLDER_MODE_AVAIL & (0x01U)) << 3);
+
+  *_len = BRAKE_DECCEL_AUX_RPT_DLC;
+  *_ide = BRAKE_DECCEL_AUX_RPT_IDE;
+  return BRAKE_DECCEL_AUX_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->VEHICLE_SPEED_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEHICLE_SPEED_phys = (sigfloat_t)(PACMOD5_VEHICLE_SPEED_ro_fromS(_m->VEHICLE_SPEED_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->VEHICLE_SPEED_VALID = (_d[2] & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < VEHICLE_SPEED_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_VEHICLE_SPEED_RPT_pacmod5(&_m->mon1, VEHICLE_SPEED_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return VEHICLE_SPEED_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < VEHICLE_SPEED_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEHICLE_SPEED_ro = PACMOD5_VEHICLE_SPEED_ro_toS(_m->VEHICLE_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->VEHICLE_SPEED_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->VEHICLE_SPEED_ro & (0xFFU));
+  cframe->Data[2] |= (_m->VEHICLE_SPEED_VALID & (0x01U));
+
+  cframe->MsgId = VEHICLE_SPEED_RPT_CANID;
+  cframe->DLC = VEHICLE_SPEED_RPT_DLC;
+  cframe->IDE = VEHICLE_SPEED_RPT_IDE;
+  return VEHICLE_SPEED_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < VEHICLE_SPEED_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEHICLE_SPEED_ro = PACMOD5_VEHICLE_SPEED_ro_toS(_m->VEHICLE_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->VEHICLE_SPEED_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->VEHICLE_SPEED_ro & (0xFFU));
+  _d[2] |= (_m->VEHICLE_SPEED_VALID & (0x01U));
+
+  *_len = VEHICLE_SPEED_RPT_DLC;
+  *_ide = VEHICLE_SPEED_RPT_IDE;
+  return VEHICLE_SPEED_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MOTOR_CURRENT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_phys = (sigfloat_t)(PACMOD5_MOTOR_CURRENT_ro_fromS(_m->MOTOR_CURRENT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->SHAFT_POSITION_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->SHAFT_POSITION_phys = (sigfloat_t)(PACMOD5_SHAFT_POSITION_ro_fromS(_m->SHAFT_POSITION_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_MOTOR_RPT_1_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_MOTOR_RPT_1_pacmod5(&_m->mon1, BRAKE_MOTOR_RPT_1_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_MOTOR_RPT_1_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_1_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_ro = PACMOD5_MOTOR_CURRENT_ro_toS(_m->MOTOR_CURRENT_phys);
+  _m->SHAFT_POSITION_ro = PACMOD5_SHAFT_POSITION_ro_toS(_m->SHAFT_POSITION_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->MOTOR_CURRENT_ro >> 24) & (0xFFU));
+  cframe->Data[1] |= ((_m->MOTOR_CURRENT_ro >> 16) & (0xFFU));
+  cframe->Data[2] |= ((_m->MOTOR_CURRENT_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->MOTOR_CURRENT_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->SHAFT_POSITION_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->SHAFT_POSITION_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->SHAFT_POSITION_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->SHAFT_POSITION_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_MOTOR_RPT_1_CANID;
+  cframe->DLC = BRAKE_MOTOR_RPT_1_DLC;
+  cframe->IDE = BRAKE_MOTOR_RPT_1_IDE;
+  return BRAKE_MOTOR_RPT_1_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_1_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_ro = PACMOD5_MOTOR_CURRENT_ro_toS(_m->MOTOR_CURRENT_phys);
+  _m->SHAFT_POSITION_ro = PACMOD5_SHAFT_POSITION_ro_toS(_m->SHAFT_POSITION_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->MOTOR_CURRENT_ro >> 24) & (0xFFU));
+  _d[1] |= ((_m->MOTOR_CURRENT_ro >> 16) & (0xFFU));
+  _d[2] |= ((_m->MOTOR_CURRENT_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->MOTOR_CURRENT_ro & (0xFFU));
+  _d[4] |= ((_m->SHAFT_POSITION_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->SHAFT_POSITION_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->SHAFT_POSITION_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->SHAFT_POSITION_ro & (0xFFU));
+
+  *_len = BRAKE_MOTOR_RPT_1_DLC;
+  *_ide = BRAKE_MOTOR_RPT_1_IDE;
+  return BRAKE_MOTOR_RPT_1_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENCODER_TEMPERATURE = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->MOTOR_TEMPERATURE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->ANGULAR_SPEED_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_phys = (sigfloat_t)(PACMOD5_ANGULAR_SPEED_ro_fromS(_m->ANGULAR_SPEED_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_MOTOR_RPT_2_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_MOTOR_RPT_2_pacmod5(&_m->mon1, BRAKE_MOTOR_RPT_2_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_MOTOR_RPT_2_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_2_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_ro = PACMOD5_ANGULAR_SPEED_ro_toS(_m->ANGULAR_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->ENCODER_TEMPERATURE >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->ENCODER_TEMPERATURE & (0xFFU));
+  cframe->Data[2] |= ((_m->MOTOR_TEMPERATURE >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->MOTOR_TEMPERATURE & (0xFFU));
+  cframe->Data[4] |= ((_m->ANGULAR_SPEED_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->ANGULAR_SPEED_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->ANGULAR_SPEED_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->ANGULAR_SPEED_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_MOTOR_RPT_2_CANID;
+  cframe->DLC = BRAKE_MOTOR_RPT_2_DLC;
+  cframe->IDE = BRAKE_MOTOR_RPT_2_IDE;
+  return BRAKE_MOTOR_RPT_2_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_2_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_ro = PACMOD5_ANGULAR_SPEED_ro_toS(_m->ANGULAR_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->ENCODER_TEMPERATURE >> 8) & (0xFFU));
+  _d[1] |= (_m->ENCODER_TEMPERATURE & (0xFFU));
+  _d[2] |= ((_m->MOTOR_TEMPERATURE >> 8) & (0xFFU));
+  _d[3] |= (_m->MOTOR_TEMPERATURE & (0xFFU));
+  _d[4] |= ((_m->ANGULAR_SPEED_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->ANGULAR_SPEED_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->ANGULAR_SPEED_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->ANGULAR_SPEED_ro & (0xFFU));
+
+  *_len = BRAKE_MOTOR_RPT_2_DLC;
+  *_ide = BRAKE_MOTOR_RPT_2_IDE;
+  return BRAKE_MOTOR_RPT_2_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->TORQUE_OUTPUT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_phys = (sigfloat_t)(PACMOD5_TORQUE_OUTPUT_ro_fromS(_m->TORQUE_OUTPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->TORQUE_INPUT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_INPUT_phys = (sigfloat_t)(PACMOD5_TORQUE_INPUT_ro_fromS(_m->TORQUE_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < BRAKE_MOTOR_RPT_3_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_BRAKE_MOTOR_RPT_3_pacmod5(&_m->mon1, BRAKE_MOTOR_RPT_3_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return BRAKE_MOTOR_RPT_3_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_3_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_ro = PACMOD5_TORQUE_OUTPUT_ro_toS(_m->TORQUE_OUTPUT_phys);
+  _m->TORQUE_INPUT_ro = PACMOD5_TORQUE_INPUT_ro_toS(_m->TORQUE_INPUT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->TORQUE_OUTPUT_ro >> 24) & (0xFFU));
+  cframe->Data[1] |= ((_m->TORQUE_OUTPUT_ro >> 16) & (0xFFU));
+  cframe->Data[2] |= ((_m->TORQUE_OUTPUT_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->TORQUE_OUTPUT_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->TORQUE_INPUT_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->TORQUE_INPUT_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->TORQUE_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->TORQUE_INPUT_ro & (0xFFU));
+
+  cframe->MsgId = BRAKE_MOTOR_RPT_3_CANID;
+  cframe->DLC = BRAKE_MOTOR_RPT_3_DLC;
+  cframe->IDE = BRAKE_MOTOR_RPT_3_IDE;
+  return BRAKE_MOTOR_RPT_3_CANID;
+}
+
+#else
+
+uint32_t Pack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < BRAKE_MOTOR_RPT_3_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_ro = PACMOD5_TORQUE_OUTPUT_ro_toS(_m->TORQUE_OUTPUT_phys);
+  _m->TORQUE_INPUT_ro = PACMOD5_TORQUE_INPUT_ro_toS(_m->TORQUE_INPUT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->TORQUE_OUTPUT_ro >> 24) & (0xFFU));
+  _d[1] |= ((_m->TORQUE_OUTPUT_ro >> 16) & (0xFFU));
+  _d[2] |= ((_m->TORQUE_OUTPUT_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->TORQUE_OUTPUT_ro & (0xFFU));
+  _d[4] |= ((_m->TORQUE_INPUT_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->TORQUE_INPUT_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->TORQUE_INPUT_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->TORQUE_INPUT_ro & (0xFFU));
+
+  *_len = BRAKE_MOTOR_RPT_3_DLC;
+  *_ide = BRAKE_MOTOR_RPT_3_IDE;
+  return BRAKE_MOTOR_RPT_3_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MOTOR_CURRENT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_phys = (sigfloat_t)(PACMOD5_MOTOR_CURRENT_ro_fromS(_m->MOTOR_CURRENT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->SHAFT_POSITION_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->SHAFT_POSITION_phys = (sigfloat_t)(PACMOD5_SHAFT_POSITION_ro_fromS(_m->SHAFT_POSITION_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_MOTOR_RPT_1_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_MOTOR_RPT_1_pacmod5(&_m->mon1, STEERING_MOTOR_RPT_1_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_MOTOR_RPT_1_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_1_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_ro = PACMOD5_MOTOR_CURRENT_ro_toS(_m->MOTOR_CURRENT_phys);
+  _m->SHAFT_POSITION_ro = PACMOD5_SHAFT_POSITION_ro_toS(_m->SHAFT_POSITION_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->MOTOR_CURRENT_ro >> 24) & (0xFFU));
+  cframe->Data[1] |= ((_m->MOTOR_CURRENT_ro >> 16) & (0xFFU));
+  cframe->Data[2] |= ((_m->MOTOR_CURRENT_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->MOTOR_CURRENT_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->SHAFT_POSITION_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->SHAFT_POSITION_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->SHAFT_POSITION_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->SHAFT_POSITION_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_MOTOR_RPT_1_CANID;
+  cframe->DLC = STEERING_MOTOR_RPT_1_DLC;
+  cframe->IDE = STEERING_MOTOR_RPT_1_IDE;
+  return STEERING_MOTOR_RPT_1_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_1_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->MOTOR_CURRENT_ro = PACMOD5_MOTOR_CURRENT_ro_toS(_m->MOTOR_CURRENT_phys);
+  _m->SHAFT_POSITION_ro = PACMOD5_SHAFT_POSITION_ro_toS(_m->SHAFT_POSITION_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->MOTOR_CURRENT_ro >> 24) & (0xFFU));
+  _d[1] |= ((_m->MOTOR_CURRENT_ro >> 16) & (0xFFU));
+  _d[2] |= ((_m->MOTOR_CURRENT_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->MOTOR_CURRENT_ro & (0xFFU));
+  _d[4] |= ((_m->SHAFT_POSITION_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->SHAFT_POSITION_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->SHAFT_POSITION_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->SHAFT_POSITION_ro & (0xFFU));
+
+  *_len = STEERING_MOTOR_RPT_1_DLC;
+  *_ide = STEERING_MOTOR_RPT_1_IDE;
+  return STEERING_MOTOR_RPT_1_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ENCODER_TEMPERATURE = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+  _m->MOTOR_TEMPERATURE = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+  _m->ANGULAR_SPEED_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_phys = (sigfloat_t)(PACMOD5_ANGULAR_SPEED_ro_fromS(_m->ANGULAR_SPEED_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_MOTOR_RPT_2_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_MOTOR_RPT_2_pacmod5(&_m->mon1, STEERING_MOTOR_RPT_2_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_MOTOR_RPT_2_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_2_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_ro = PACMOD5_ANGULAR_SPEED_ro_toS(_m->ANGULAR_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->ENCODER_TEMPERATURE >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->ENCODER_TEMPERATURE & (0xFFU));
+  cframe->Data[2] |= ((_m->MOTOR_TEMPERATURE >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->MOTOR_TEMPERATURE & (0xFFU));
+  cframe->Data[4] |= ((_m->ANGULAR_SPEED_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->ANGULAR_SPEED_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->ANGULAR_SPEED_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->ANGULAR_SPEED_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_MOTOR_RPT_2_CANID;
+  cframe->DLC = STEERING_MOTOR_RPT_2_DLC;
+  cframe->IDE = STEERING_MOTOR_RPT_2_IDE;
+  return STEERING_MOTOR_RPT_2_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_2_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ANGULAR_SPEED_ro = PACMOD5_ANGULAR_SPEED_ro_toS(_m->ANGULAR_SPEED_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->ENCODER_TEMPERATURE >> 8) & (0xFFU));
+  _d[1] |= (_m->ENCODER_TEMPERATURE & (0xFFU));
+  _d[2] |= ((_m->MOTOR_TEMPERATURE >> 8) & (0xFFU));
+  _d[3] |= (_m->MOTOR_TEMPERATURE & (0xFFU));
+  _d[4] |= ((_m->ANGULAR_SPEED_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->ANGULAR_SPEED_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->ANGULAR_SPEED_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->ANGULAR_SPEED_ro & (0xFFU));
+
+  *_len = STEERING_MOTOR_RPT_2_DLC;
+  *_ide = STEERING_MOTOR_RPT_2_IDE;
+  return STEERING_MOTOR_RPT_2_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->TORQUE_OUTPUT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 24) | ((_d[1] & (0xFFU)) << 16) | ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_phys = (sigfloat_t)(PACMOD5_TORQUE_OUTPUT_ro_fromS(_m->TORQUE_OUTPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->TORQUE_INPUT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 24) | ((_d[5] & (0xFFU)) << 16) | ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 32);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_INPUT_phys = (sigfloat_t)(PACMOD5_TORQUE_INPUT_ro_fromS(_m->TORQUE_INPUT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < STEERING_MOTOR_RPT_3_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_STEERING_MOTOR_RPT_3_pacmod5(&_m->mon1, STEERING_MOTOR_RPT_3_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return STEERING_MOTOR_RPT_3_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_3_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_ro = PACMOD5_TORQUE_OUTPUT_ro_toS(_m->TORQUE_OUTPUT_phys);
+  _m->TORQUE_INPUT_ro = PACMOD5_TORQUE_INPUT_ro_toS(_m->TORQUE_INPUT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->TORQUE_OUTPUT_ro >> 24) & (0xFFU));
+  cframe->Data[1] |= ((_m->TORQUE_OUTPUT_ro >> 16) & (0xFFU));
+  cframe->Data[2] |= ((_m->TORQUE_OUTPUT_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->TORQUE_OUTPUT_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->TORQUE_INPUT_ro >> 24) & (0xFFU));
+  cframe->Data[5] |= ((_m->TORQUE_INPUT_ro >> 16) & (0xFFU));
+  cframe->Data[6] |= ((_m->TORQUE_INPUT_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->TORQUE_INPUT_ro & (0xFFU));
+
+  cframe->MsgId = STEERING_MOTOR_RPT_3_CANID;
+  cframe->DLC = STEERING_MOTOR_RPT_3_DLC;
+  cframe->IDE = STEERING_MOTOR_RPT_3_IDE;
+  return STEERING_MOTOR_RPT_3_CANID;
+}
+
+#else
+
+uint32_t Pack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < STEERING_MOTOR_RPT_3_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->TORQUE_OUTPUT_ro = PACMOD5_TORQUE_OUTPUT_ro_toS(_m->TORQUE_OUTPUT_phys);
+  _m->TORQUE_INPUT_ro = PACMOD5_TORQUE_INPUT_ro_toS(_m->TORQUE_INPUT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->TORQUE_OUTPUT_ro >> 24) & (0xFFU));
+  _d[1] |= ((_m->TORQUE_OUTPUT_ro >> 16) & (0xFFU));
+  _d[2] |= ((_m->TORQUE_OUTPUT_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->TORQUE_OUTPUT_ro & (0xFFU));
+  _d[4] |= ((_m->TORQUE_INPUT_ro >> 24) & (0xFFU));
+  _d[5] |= ((_m->TORQUE_INPUT_ro >> 16) & (0xFFU));
+  _d[6] |= ((_m->TORQUE_INPUT_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->TORQUE_INPUT_ro & (0xFFU));
+
+  *_len = STEERING_MOTOR_RPT_3_DLC;
+  *_ide = STEERING_MOTOR_RPT_3_IDE;
+  return STEERING_MOTOR_RPT_3_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->WHEEL_SPD_FRONT_LEFT_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_FRONT_LEFT_phys = (sigfloat_t)(PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_fromS(_m->WHEEL_SPD_FRONT_LEFT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->WHEEL_SPD_FRONT_RIGHT_ro = __ext_sig__(( ((_d[2] & (0xFFU)) << 8) | (_d[3] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_FRONT_RIGHT_phys = (sigfloat_t)(PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_fromS(_m->WHEEL_SPD_FRONT_RIGHT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->WHEEL_SPD_REAR_LEFT_ro = __ext_sig__(( ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_REAR_LEFT_phys = (sigfloat_t)(PACMOD5_WHEEL_SPD_REAR_LEFT_ro_fromS(_m->WHEEL_SPD_REAR_LEFT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->WHEEL_SPD_REAR_RIGHT_ro = __ext_sig__(( ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_REAR_RIGHT_phys = (sigfloat_t)(PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_fromS(_m->WHEEL_SPD_REAR_RIGHT_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < WHEEL_SPEED_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_WHEEL_SPEED_RPT_pacmod5(&_m->mon1, WHEEL_SPEED_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return WHEEL_SPEED_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < WHEEL_SPEED_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_FRONT_LEFT_ro = PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_toS(_m->WHEEL_SPD_FRONT_LEFT_phys);
+  _m->WHEEL_SPD_FRONT_RIGHT_ro = PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_toS(_m->WHEEL_SPD_FRONT_RIGHT_phys);
+  _m->WHEEL_SPD_REAR_LEFT_ro = PACMOD5_WHEEL_SPD_REAR_LEFT_ro_toS(_m->WHEEL_SPD_REAR_LEFT_phys);
+  _m->WHEEL_SPD_REAR_RIGHT_ro = PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_toS(_m->WHEEL_SPD_REAR_RIGHT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->WHEEL_SPD_FRONT_LEFT_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->WHEEL_SPD_FRONT_LEFT_ro & (0xFFU));
+  cframe->Data[2] |= ((_m->WHEEL_SPD_FRONT_RIGHT_ro >> 8) & (0xFFU));
+  cframe->Data[3] |= (_m->WHEEL_SPD_FRONT_RIGHT_ro & (0xFFU));
+  cframe->Data[4] |= ((_m->WHEEL_SPD_REAR_LEFT_ro >> 8) & (0xFFU));
+  cframe->Data[5] |= (_m->WHEEL_SPD_REAR_LEFT_ro & (0xFFU));
+  cframe->Data[6] |= ((_m->WHEEL_SPD_REAR_RIGHT_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->WHEEL_SPD_REAR_RIGHT_ro & (0xFFU));
+
+  cframe->MsgId = WHEEL_SPEED_RPT_CANID;
+  cframe->DLC = WHEEL_SPEED_RPT_DLC;
+  cframe->IDE = WHEEL_SPEED_RPT_IDE;
+  return WHEEL_SPEED_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < WHEEL_SPEED_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->WHEEL_SPD_FRONT_LEFT_ro = PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_toS(_m->WHEEL_SPD_FRONT_LEFT_phys);
+  _m->WHEEL_SPD_FRONT_RIGHT_ro = PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_toS(_m->WHEEL_SPD_FRONT_RIGHT_phys);
+  _m->WHEEL_SPD_REAR_LEFT_ro = PACMOD5_WHEEL_SPD_REAR_LEFT_ro_toS(_m->WHEEL_SPD_REAR_LEFT_phys);
+  _m->WHEEL_SPD_REAR_RIGHT_ro = PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_toS(_m->WHEEL_SPD_REAR_RIGHT_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->WHEEL_SPD_FRONT_LEFT_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->WHEEL_SPD_FRONT_LEFT_ro & (0xFFU));
+  _d[2] |= ((_m->WHEEL_SPD_FRONT_RIGHT_ro >> 8) & (0xFFU));
+  _d[3] |= (_m->WHEEL_SPD_FRONT_RIGHT_ro & (0xFFU));
+  _d[4] |= ((_m->WHEEL_SPD_REAR_LEFT_ro >> 8) & (0xFFU));
+  _d[5] |= (_m->WHEEL_SPD_REAR_LEFT_ro & (0xFFU));
+  _d[6] |= ((_m->WHEEL_SPD_REAR_RIGHT_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->WHEEL_SPD_REAR_RIGHT_ro & (0xFFU));
+
+  *_len = WHEEL_SPEED_RPT_DLC;
+  *_ide = WHEEL_SPEED_RPT_IDE;
+  return WHEEL_SPEED_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MAJOR = (_d[0] & (0xFFU));
+  _m->MINOR = (_d[1] & (0xFFU));
+  _m->PATCH = (_d[2] & (0xFFU));
+  _m->BUILD0 = (_d[3] & (0xFFU));
+  _m->BUILD1 = (_d[4] & (0xFFU));
+  _m->BUILD2 = (_d[5] & (0xFFU));
+  _m->BUILD3 = (_d[6] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SOFTWARE_VERSION_RPT_00_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SOFTWARE_VERSION_RPT_00_pacmod5(&_m->mon1, SOFTWARE_VERSION_RPT_00_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SOFTWARE_VERSION_RPT_00_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_00_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->MAJOR & (0xFFU));
+  cframe->Data[1] |= (_m->MINOR & (0xFFU));
+  cframe->Data[2] |= (_m->PATCH & (0xFFU));
+  cframe->Data[3] |= (_m->BUILD0 & (0xFFU));
+  cframe->Data[4] |= (_m->BUILD1 & (0xFFU));
+  cframe->Data[5] |= (_m->BUILD2 & (0xFFU));
+  cframe->Data[6] |= (_m->BUILD3 & (0xFFU));
+
+  cframe->MsgId = SOFTWARE_VERSION_RPT_00_CANID;
+  cframe->DLC = SOFTWARE_VERSION_RPT_00_DLC;
+  cframe->IDE = SOFTWARE_VERSION_RPT_00_IDE;
+  return SOFTWARE_VERSION_RPT_00_CANID;
+}
+
+#else
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_00_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->MAJOR & (0xFFU));
+  _d[1] |= (_m->MINOR & (0xFFU));
+  _d[2] |= (_m->PATCH & (0xFFU));
+  _d[3] |= (_m->BUILD0 & (0xFFU));
+  _d[4] |= (_m->BUILD1 & (0xFFU));
+  _d[5] |= (_m->BUILD2 & (0xFFU));
+  _d[6] |= (_m->BUILD3 & (0xFFU));
+
+  *_len = SOFTWARE_VERSION_RPT_00_DLC;
+  *_ide = SOFTWARE_VERSION_RPT_00_IDE;
+  return SOFTWARE_VERSION_RPT_00_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MAJOR = (_d[0] & (0xFFU));
+  _m->MINOR = (_d[1] & (0xFFU));
+  _m->PATCH = (_d[2] & (0xFFU));
+  _m->BUILD0 = (_d[3] & (0xFFU));
+  _m->BUILD1 = (_d[4] & (0xFFU));
+  _m->BUILD2 = (_d[5] & (0xFFU));
+  _m->BUILD3 = (_d[6] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SOFTWARE_VERSION_RPT_01_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SOFTWARE_VERSION_RPT_01_pacmod5(&_m->mon1, SOFTWARE_VERSION_RPT_01_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SOFTWARE_VERSION_RPT_01_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_01_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->MAJOR & (0xFFU));
+  cframe->Data[1] |= (_m->MINOR & (0xFFU));
+  cframe->Data[2] |= (_m->PATCH & (0xFFU));
+  cframe->Data[3] |= (_m->BUILD0 & (0xFFU));
+  cframe->Data[4] |= (_m->BUILD1 & (0xFFU));
+  cframe->Data[5] |= (_m->BUILD2 & (0xFFU));
+  cframe->Data[6] |= (_m->BUILD3 & (0xFFU));
+
+  cframe->MsgId = SOFTWARE_VERSION_RPT_01_CANID;
+  cframe->DLC = SOFTWARE_VERSION_RPT_01_DLC;
+  cframe->IDE = SOFTWARE_VERSION_RPT_01_IDE;
+  return SOFTWARE_VERSION_RPT_01_CANID;
+}
+
+#else
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_01_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->MAJOR & (0xFFU));
+  _d[1] |= (_m->MINOR & (0xFFU));
+  _d[2] |= (_m->PATCH & (0xFFU));
+  _d[3] |= (_m->BUILD0 & (0xFFU));
+  _d[4] |= (_m->BUILD1 & (0xFFU));
+  _d[5] |= (_m->BUILD2 & (0xFFU));
+  _d[6] |= (_m->BUILD3 & (0xFFU));
+
+  *_len = SOFTWARE_VERSION_RPT_01_DLC;
+  *_ide = SOFTWARE_VERSION_RPT_01_IDE;
+  return SOFTWARE_VERSION_RPT_01_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MAJOR = (_d[0] & (0xFFU));
+  _m->MINOR = (_d[1] & (0xFFU));
+  _m->PATCH = (_d[2] & (0xFFU));
+  _m->BUILD0 = (_d[3] & (0xFFU));
+  _m->BUILD1 = (_d[4] & (0xFFU));
+  _m->BUILD2 = (_d[5] & (0xFFU));
+  _m->BUILD3 = (_d[6] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SOFTWARE_VERSION_RPT_02_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SOFTWARE_VERSION_RPT_02_pacmod5(&_m->mon1, SOFTWARE_VERSION_RPT_02_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SOFTWARE_VERSION_RPT_02_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_02_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->MAJOR & (0xFFU));
+  cframe->Data[1] |= (_m->MINOR & (0xFFU));
+  cframe->Data[2] |= (_m->PATCH & (0xFFU));
+  cframe->Data[3] |= (_m->BUILD0 & (0xFFU));
+  cframe->Data[4] |= (_m->BUILD1 & (0xFFU));
+  cframe->Data[5] |= (_m->BUILD2 & (0xFFU));
+  cframe->Data[6] |= (_m->BUILD3 & (0xFFU));
+
+  cframe->MsgId = SOFTWARE_VERSION_RPT_02_CANID;
+  cframe->DLC = SOFTWARE_VERSION_RPT_02_DLC;
+  cframe->IDE = SOFTWARE_VERSION_RPT_02_IDE;
+  return SOFTWARE_VERSION_RPT_02_CANID;
+}
+
+#else
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_02_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->MAJOR & (0xFFU));
+  _d[1] |= (_m->MINOR & (0xFFU));
+  _d[2] |= (_m->PATCH & (0xFFU));
+  _d[3] |= (_m->BUILD0 & (0xFFU));
+  _d[4] |= (_m->BUILD1 & (0xFFU));
+  _d[5] |= (_m->BUILD2 & (0xFFU));
+  _d[6] |= (_m->BUILD3 & (0xFFU));
+
+  *_len = SOFTWARE_VERSION_RPT_02_DLC;
+  *_ide = SOFTWARE_VERSION_RPT_02_IDE;
+  return SOFTWARE_VERSION_RPT_02_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->MAJOR = (_d[0] & (0xFFU));
+  _m->MINOR = (_d[1] & (0xFFU));
+  _m->PATCH = (_d[2] & (0xFFU));
+  _m->BUILD0 = (_d[3] & (0xFFU));
+  _m->BUILD1 = (_d[4] & (0xFFU));
+  _m->BUILD2 = (_d[5] & (0xFFU));
+  _m->BUILD3 = (_d[6] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < SOFTWARE_VERSION_RPT_03_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_SOFTWARE_VERSION_RPT_03_pacmod5(&_m->mon1, SOFTWARE_VERSION_RPT_03_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return SOFTWARE_VERSION_RPT_03_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_03_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->MAJOR & (0xFFU));
+  cframe->Data[1] |= (_m->MINOR & (0xFFU));
+  cframe->Data[2] |= (_m->PATCH & (0xFFU));
+  cframe->Data[3] |= (_m->BUILD0 & (0xFFU));
+  cframe->Data[4] |= (_m->BUILD1 & (0xFFU));
+  cframe->Data[5] |= (_m->BUILD2 & (0xFFU));
+  cframe->Data[6] |= (_m->BUILD3 & (0xFFU));
+
+  cframe->MsgId = SOFTWARE_VERSION_RPT_03_CANID;
+  cframe->DLC = SOFTWARE_VERSION_RPT_03_DLC;
+  cframe->IDE = SOFTWARE_VERSION_RPT_03_IDE;
+  return SOFTWARE_VERSION_RPT_03_CANID;
+}
+
+#else
+
+uint32_t Pack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < SOFTWARE_VERSION_RPT_03_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->MAJOR & (0xFFU));
+  _d[1] |= (_m->MINOR & (0xFFU));
+  _d[2] |= (_m->PATCH & (0xFFU));
+  _d[3] |= (_m->BUILD0 & (0xFFU));
+  _d[4] |= (_m->BUILD1 & (0xFFU));
+  _d[5] |= (_m->BUILD2 & (0xFFU));
+  _d[6] |= (_m->BUILD3 & (0xFFU));
+
+  *_len = SOFTWARE_VERSION_RPT_03_DLC;
+  *_ide = SOFTWARE_VERSION_RPT_03_IDE;
+  return SOFTWARE_VERSION_RPT_03_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->YAW_RATE_ro = __ext_sig__(( ((_d[0] & (0xFFU)) << 8) | (_d[1] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->YAW_RATE_phys = (sigfloat_t)(PACMOD5_YAW_RATE_ro_fromS(_m->YAW_RATE_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < YAW_RATE_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_YAW_RATE_RPT_pacmod5(&_m->mon1, YAW_RATE_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return YAW_RATE_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < YAW_RATE_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->YAW_RATE_ro = PACMOD5_YAW_RATE_ro_toS(_m->YAW_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->YAW_RATE_ro >> 8) & (0xFFU));
+  cframe->Data[1] |= (_m->YAW_RATE_ro & (0xFFU));
+
+  cframe->MsgId = YAW_RATE_RPT_CANID;
+  cframe->DLC = YAW_RATE_RPT_DLC;
+  cframe->IDE = YAW_RATE_RPT_IDE;
+  return YAW_RATE_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < YAW_RATE_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->YAW_RATE_ro = PACMOD5_YAW_RATE_ro_toS(_m->YAW_RATE_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->YAW_RATE_ro >> 8) & (0xFFU));
+  _d[1] |= (_m->YAW_RATE_ro & (0xFFU));
+
+  *_len = YAW_RATE_RPT_DLC;
+  *_ide = YAW_RATE_RPT_IDE;
+  return YAW_RATE_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->LATITUDE_DEGREES = __ext_sig__(( (_d[0] & (0xFFU)) ), 8);
+  _m->LATITUDE_MINUTES = __ext_sig__(( (_d[1] & (0xFFU)) ), 8);
+  _m->LATITUDE_SECONDS = __ext_sig__(( (_d[2] & (0xFFU)) ), 8);
+  _m->LONGITUDE_DEGREES = __ext_sig__(( (_d[3] & (0xFFU)) ), 8);
+  _m->LONGITUDE_MINUTES = __ext_sig__(( (_d[4] & (0xFFU)) ), 8);
+  _m->LONGITUDE_SECONDS = __ext_sig__(( (_d[5] & (0xFFU)) ), 8);
+  _m->HEADING_ro = __ext_sig__(( ((_d[6] & (0xFFU)) << 8) | (_d[7] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->HEADING_phys = (sigfloat_t)(PACMOD5_HEADING_ro_fromS(_m->HEADING_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < LAT_LON_HEADING_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_LAT_LON_HEADING_RPT_pacmod5(&_m->mon1, LAT_LON_HEADING_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return LAT_LON_HEADING_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < LAT_LON_HEADING_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->HEADING_ro = PACMOD5_HEADING_ro_toS(_m->HEADING_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->LATITUDE_DEGREES & (0xFFU));
+  cframe->Data[1] |= (_m->LATITUDE_MINUTES & (0xFFU));
+  cframe->Data[2] |= (_m->LATITUDE_SECONDS & (0xFFU));
+  cframe->Data[3] |= (_m->LONGITUDE_DEGREES & (0xFFU));
+  cframe->Data[4] |= (_m->LONGITUDE_MINUTES & (0xFFU));
+  cframe->Data[5] |= (_m->LONGITUDE_SECONDS & (0xFFU));
+  cframe->Data[6] |= ((_m->HEADING_ro >> 8) & (0xFFU));
+  cframe->Data[7] |= (_m->HEADING_ro & (0xFFU));
+
+  cframe->MsgId = LAT_LON_HEADING_RPT_CANID;
+  cframe->DLC = LAT_LON_HEADING_RPT_DLC;
+  cframe->IDE = LAT_LON_HEADING_RPT_IDE;
+  return LAT_LON_HEADING_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < LAT_LON_HEADING_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->HEADING_ro = PACMOD5_HEADING_ro_toS(_m->HEADING_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->LATITUDE_DEGREES & (0xFFU));
+  _d[1] |= (_m->LATITUDE_MINUTES & (0xFFU));
+  _d[2] |= (_m->LATITUDE_SECONDS & (0xFFU));
+  _d[3] |= (_m->LONGITUDE_DEGREES & (0xFFU));
+  _d[4] |= (_m->LONGITUDE_MINUTES & (0xFFU));
+  _d[5] |= (_m->LONGITUDE_SECONDS & (0xFFU));
+  _d[6] |= ((_m->HEADING_ro >> 8) & (0xFFU));
+  _d[7] |= (_m->HEADING_ro & (0xFFU));
+
+  *_len = LAT_LON_HEADING_RPT_DLC;
+  *_ide = LAT_LON_HEADING_RPT_IDE;
+  return LAT_LON_HEADING_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->DATE_YEAR_ro = (_d[0] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->DATE_YEAR_phys = PACMOD5_DATE_YEAR_ro_fromS(_m->DATE_YEAR_ro);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->DATE_MONTH_ro = (_d[1] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->DATE_MONTH_phys = PACMOD5_DATE_MONTH_ro_fromS(_m->DATE_MONTH_ro);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->DATE_DAY_ro = (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->DATE_DAY_phys = PACMOD5_DATE_DAY_ro_fromS(_m->DATE_DAY_ro);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->TIME_HOUR = (_d[3] & (0xFFU));
+  _m->TIME_MINUTE = (_d[4] & (0xFFU));
+  _m->TIME_SECOND = (_d[5] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DATE_TIME_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DATE_TIME_RPT_pacmod5(&_m->mon1, DATE_TIME_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DATE_TIME_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DATE_TIME_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->DATE_YEAR_ro = PACMOD5_DATE_YEAR_ro_toS(_m->DATE_YEAR_phys);
+  _m->DATE_MONTH_ro = PACMOD5_DATE_MONTH_ro_toS(_m->DATE_MONTH_phys);
+  _m->DATE_DAY_ro = PACMOD5_DATE_DAY_ro_toS(_m->DATE_DAY_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->DATE_YEAR_ro & (0xFFU));
+  cframe->Data[1] |= (_m->DATE_MONTH_ro & (0xFFU));
+  cframe->Data[2] |= (_m->DATE_DAY_ro & (0xFFU));
+  cframe->Data[3] |= (_m->TIME_HOUR & (0xFFU));
+  cframe->Data[4] |= (_m->TIME_MINUTE & (0xFFU));
+  cframe->Data[5] |= (_m->TIME_SECOND & (0xFFU));
+
+  cframe->MsgId = DATE_TIME_RPT_CANID;
+  cframe->DLC = DATE_TIME_RPT_DLC;
+  cframe->IDE = DATE_TIME_RPT_IDE;
+  return DATE_TIME_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DATE_TIME_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->DATE_YEAR_ro = PACMOD5_DATE_YEAR_ro_toS(_m->DATE_YEAR_phys);
+  _m->DATE_MONTH_ro = PACMOD5_DATE_MONTH_ro_toS(_m->DATE_MONTH_phys);
+  _m->DATE_DAY_ro = PACMOD5_DATE_DAY_ro_toS(_m->DATE_DAY_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->DATE_YEAR_ro & (0xFFU));
+  _d[1] |= (_m->DATE_MONTH_ro & (0xFFU));
+  _d[2] |= (_m->DATE_DAY_ro & (0xFFU));
+  _d[3] |= (_m->TIME_HOUR & (0xFFU));
+  _d[4] |= (_m->TIME_MINUTE & (0xFFU));
+  _d[5] |= (_m->TIME_SECOND & (0xFFU));
+
+  *_len = DATE_TIME_RPT_DLC;
+  *_ide = DATE_TIME_RPT_IDE;
+  return DATE_TIME_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->FRONT_OBJECT_DISTANCE_LOW_RES_ro = ((_d[0] & (0xFFU)) << 16) | ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->FRONT_OBJECT_DISTANCE_LOW_RES_phys = (sigfloat_t)(PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_fromS(_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro = ((_d[3] & (0xFFU)) << 16) | ((_d[4] & (0xFFU)) << 8) | (_d[5] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->FRONT_OBJECT_DISTANCE_HIGH_RES_phys = (sigfloat_t)(PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_fromS(_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DETECTED_OBJECT_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DETECTED_OBJECT_RPT_pacmod5(&_m->mon1, DETECTED_OBJECT_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DETECTED_OBJECT_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DETECTED_OBJECT_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->FRONT_OBJECT_DISTANCE_LOW_RES_ro = PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_toS(_m->FRONT_OBJECT_DISTANCE_LOW_RES_phys);
+  _m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro = PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_toS(_m->FRONT_OBJECT_DISTANCE_HIGH_RES_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= ((_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro >> 16) & (0xFFU));
+  cframe->Data[1] |= ((_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro >> 16) & (0xFFU));
+  cframe->Data[4] |= ((_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro >> 8) & (0xFFU));
+  cframe->Data[5] |= (_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro & (0xFFU));
+
+  cframe->MsgId = DETECTED_OBJECT_RPT_CANID;
+  cframe->DLC = DETECTED_OBJECT_RPT_DLC;
+  cframe->IDE = DETECTED_OBJECT_RPT_IDE;
+  return DETECTED_OBJECT_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DETECTED_OBJECT_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->FRONT_OBJECT_DISTANCE_LOW_RES_ro = PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_toS(_m->FRONT_OBJECT_DISTANCE_LOW_RES_phys);
+  _m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro = PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_toS(_m->FRONT_OBJECT_DISTANCE_HIGH_RES_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= ((_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro >> 16) & (0xFFU));
+  _d[1] |= ((_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->FRONT_OBJECT_DISTANCE_LOW_RES_ro & (0xFFU));
+  _d[3] |= ((_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro >> 16) & (0xFFU));
+  _d[4] |= ((_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro >> 8) & (0xFFU));
+  _d[5] |= (_m->FRONT_OBJECT_DISTANCE_HIGH_RES_ro & (0xFFU));
+
+  *_len = DETECTED_OBJECT_RPT_DLC;
+  *_ide = DETECTED_OBJECT_RPT_IDE;
+  return DETECTED_OBJECT_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->SHIFT_POS_1 = (_d[0] & (0xFFU));
+  _m->SHIFT_POS_2 = (_d[1] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < VEH_SPECIFIC_RPT_1_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_VEH_SPECIFIC_RPT_1_pacmod5(&_m->mon1, VEH_SPECIFIC_RPT_1_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return VEH_SPECIFIC_RPT_1_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < VEH_SPECIFIC_RPT_1_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->SHIFT_POS_1 & (0xFFU));
+  cframe->Data[1] |= (_m->SHIFT_POS_2 & (0xFFU));
+
+  cframe->MsgId = VEH_SPECIFIC_RPT_1_CANID;
+  cframe->DLC = VEH_SPECIFIC_RPT_1_DLC;
+  cframe->IDE = VEH_SPECIFIC_RPT_1_IDE;
+  return VEH_SPECIFIC_RPT_1_CANID;
+}
+
+#else
+
+uint32_t Pack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < VEH_SPECIFIC_RPT_1_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->SHIFT_POS_1 & (0xFFU));
+  _d[1] |= (_m->SHIFT_POS_2 & (0xFFU));
+
+  *_len = VEH_SPECIFIC_RPT_1_DLC;
+  *_ide = VEH_SPECIFIC_RPT_1_IDE;
+  return VEH_SPECIFIC_RPT_1_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->VEH_G_FORCES_ro = (_d[0] & (0xFFU));
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEH_G_FORCES_phys = (sigfloat_t)(PACMOD5_VEH_G_FORCES_ro_fromS(_m->VEH_G_FORCES_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < VEH_DYNAMICS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_VEH_DYNAMICS_RPT_pacmod5(&_m->mon1, VEH_DYNAMICS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return VEH_DYNAMICS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < VEH_DYNAMICS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEH_G_FORCES_ro = PACMOD5_VEH_G_FORCES_ro_toS(_m->VEH_G_FORCES_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->VEH_G_FORCES_ro & (0xFFU));
+
+  cframe->MsgId = VEH_DYNAMICS_RPT_CANID;
+  cframe->DLC = VEH_DYNAMICS_RPT_DLC;
+  cframe->IDE = VEH_DYNAMICS_RPT_IDE;
+  return VEH_DYNAMICS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < VEH_DYNAMICS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VEH_G_FORCES_ro = PACMOD5_VEH_G_FORCES_ro_toS(_m->VEH_G_FORCES_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->VEH_G_FORCES_ro & (0xFFU));
+
+  *_len = VEH_DYNAMICS_RPT_DLC;
+  *_ide = VEH_DYNAMICS_RPT_IDE;
+  return VEH_DYNAMICS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VIN_RPT_pacmod5(VIN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->VEH_MFG_CODE = ((_d[0] & (0xFFU)) << 16) | ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU));
+  _m->VEH_MY_CODE = (_d[3] & (0xFFU));
+  _m->VEH_SERIAL = ((_d[4] & (0xFFU)) << 16) | ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < VIN_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_VIN_RPT_pacmod5(&_m->mon1, VIN_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return VIN_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_VIN_RPT_pacmod5(VIN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < VIN_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= ((_m->VEH_MFG_CODE >> 16) & (0xFFU));
+  cframe->Data[1] |= ((_m->VEH_MFG_CODE >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->VEH_MFG_CODE & (0xFFU));
+  cframe->Data[3] |= (_m->VEH_MY_CODE & (0xFFU));
+  cframe->Data[4] |= ((_m->VEH_SERIAL >> 16) & (0xFFU));
+  cframe->Data[5] |= ((_m->VEH_SERIAL >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->VEH_SERIAL & (0xFFU));
+
+  cframe->MsgId = VIN_RPT_CANID;
+  cframe->DLC = VIN_RPT_DLC;
+  cframe->IDE = VIN_RPT_IDE;
+  return VIN_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_VIN_RPT_pacmod5(VIN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < VIN_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= ((_m->VEH_MFG_CODE >> 16) & (0xFFU));
+  _d[1] |= ((_m->VEH_MFG_CODE >> 8) & (0xFFU));
+  _d[2] |= (_m->VEH_MFG_CODE & (0xFFU));
+  _d[3] |= (_m->VEH_MY_CODE & (0xFFU));
+  _d[4] |= ((_m->VEH_SERIAL >> 16) & (0xFFU));
+  _d[5] |= ((_m->VEH_SERIAL >> 8) & (0xFFU));
+  _d[6] |= (_m->VEH_SERIAL & (0xFFU));
+
+  *_len = VIN_RPT_DLC;
+  *_ide = VIN_RPT_IDE;
+  return VIN_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->DRIVER_SEAT_OCCUPIED = (_d[0] & (0x01U));
+  _m->PASS_SEAT_OCCUPIED = ((_d[0] >> 1) & (0x01U));
+  _m->REAR_SEAT_OCCUPIED = ((_d[0] >> 2) & (0x01U));
+  _m->DRIVER_SEATBELT_BUCKLED = ((_d[0] >> 3) & (0x01U));
+  _m->PASS_SEATBELT_BUCKLED = ((_d[0] >> 4) & (0x01U));
+  _m->REAR_SEATBELT_BUCKLED = ((_d[0] >> 5) & (0x01U));
+  _m->DRIVER_SEAT_OCCUPIED_IS_VALID = (_d[1] & (0x01U));
+  _m->PASS_SEAT_OCCUPIED_IS_VALID = ((_d[1] >> 1) & (0x01U));
+  _m->REAR_SEAT_OCCUPIED_IS_VALID = ((_d[1] >> 2) & (0x01U));
+  _m->DRIVER_SEATBELT_BUCKLED_IS_VALID = ((_d[1] >> 3) & (0x01U));
+  _m->PASS_SEATBELT_BUCKLED_IS_VALID = ((_d[1] >> 4) & (0x01U));
+  _m->REAR_SEATBELT_BUCKLED_IS_VALID = ((_d[1] >> 5) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < OCCUPANCY_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_OCCUPANCY_RPT_pacmod5(&_m->mon1, OCCUPANCY_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return OCCUPANCY_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < OCCUPANCY_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->DRIVER_SEAT_OCCUPIED & (0x01U)) | ((_m->PASS_SEAT_OCCUPIED & (0x01U)) << 1) | ((_m->REAR_SEAT_OCCUPIED & (0x01U)) << 2) | ((_m->DRIVER_SEATBELT_BUCKLED & (0x01U)) << 3) | ((_m->PASS_SEATBELT_BUCKLED & (0x01U)) << 4) | ((_m->REAR_SEATBELT_BUCKLED & (0x01U)) << 5);
+  cframe->Data[1] |= (_m->DRIVER_SEAT_OCCUPIED_IS_VALID & (0x01U)) | ((_m->PASS_SEAT_OCCUPIED_IS_VALID & (0x01U)) << 1) | ((_m->REAR_SEAT_OCCUPIED_IS_VALID & (0x01U)) << 2) | ((_m->DRIVER_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 3) | ((_m->PASS_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 4) | ((_m->REAR_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 5);
+
+  cframe->MsgId = OCCUPANCY_RPT_CANID;
+  cframe->DLC = OCCUPANCY_RPT_DLC;
+  cframe->IDE = OCCUPANCY_RPT_IDE;
+  return OCCUPANCY_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < OCCUPANCY_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->DRIVER_SEAT_OCCUPIED & (0x01U)) | ((_m->PASS_SEAT_OCCUPIED & (0x01U)) << 1) | ((_m->REAR_SEAT_OCCUPIED & (0x01U)) << 2) | ((_m->DRIVER_SEATBELT_BUCKLED & (0x01U)) << 3) | ((_m->PASS_SEATBELT_BUCKLED & (0x01U)) << 4) | ((_m->REAR_SEATBELT_BUCKLED & (0x01U)) << 5);
+  _d[1] |= (_m->DRIVER_SEAT_OCCUPIED_IS_VALID & (0x01U)) | ((_m->PASS_SEAT_OCCUPIED_IS_VALID & (0x01U)) << 1) | ((_m->REAR_SEAT_OCCUPIED_IS_VALID & (0x01U)) << 2) | ((_m->DRIVER_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 3) | ((_m->PASS_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 4) | ((_m->REAR_SEATBELT_BUCKLED_IS_VALID & (0x01U)) << 5);
+
+  *_len = OCCUPANCY_RPT_DLC;
+  *_ide = OCCUPANCY_RPT_IDE;
+  return OCCUPANCY_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->FRONT_DOME_LIGHTS_ON = (_d[0] & (0x01U));
+  _m->REAR_DOME_LIGHTS_ON = ((_d[0] >> 1) & (0x01U));
+  _m->MOOD_LIGHTS_ON = ((_d[0] >> 2) & (0x01U));
+  _m->DIM_LEVEL = (_d[1] & (0xFFU));
+  _m->FRONT_DOME_LIGHTS_ON_IS_VALID = (_d[2] & (0x01U));
+  _m->REAR_DOME_LIGHTS_ON_IS_VALID = ((_d[2] >> 1) & (0x01U));
+  _m->MOOD_LIGHTS_ON_IS_VALID = ((_d[2] >> 2) & (0x01U));
+  _m->DIM_LEVEL_IS_VALID = ((_d[2] >> 3) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < INTERIOR_LIGHTS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_INTERIOR_LIGHTS_RPT_pacmod5(&_m->mon1, INTERIOR_LIGHTS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return INTERIOR_LIGHTS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < INTERIOR_LIGHTS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->FRONT_DOME_LIGHTS_ON & (0x01U)) | ((_m->REAR_DOME_LIGHTS_ON & (0x01U)) << 1) | ((_m->MOOD_LIGHTS_ON & (0x01U)) << 2);
+  cframe->Data[1] |= (_m->DIM_LEVEL & (0xFFU));
+  cframe->Data[2] |= (_m->FRONT_DOME_LIGHTS_ON_IS_VALID & (0x01U)) | ((_m->REAR_DOME_LIGHTS_ON_IS_VALID & (0x01U)) << 1) | ((_m->MOOD_LIGHTS_ON_IS_VALID & (0x01U)) << 2) | ((_m->DIM_LEVEL_IS_VALID & (0x01U)) << 3);
+
+  cframe->MsgId = INTERIOR_LIGHTS_RPT_CANID;
+  cframe->DLC = INTERIOR_LIGHTS_RPT_DLC;
+  cframe->IDE = INTERIOR_LIGHTS_RPT_IDE;
+  return INTERIOR_LIGHTS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < INTERIOR_LIGHTS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->FRONT_DOME_LIGHTS_ON & (0x01U)) | ((_m->REAR_DOME_LIGHTS_ON & (0x01U)) << 1) | ((_m->MOOD_LIGHTS_ON & (0x01U)) << 2);
+  _d[1] |= (_m->DIM_LEVEL & (0xFFU));
+  _d[2] |= (_m->FRONT_DOME_LIGHTS_ON_IS_VALID & (0x01U)) | ((_m->REAR_DOME_LIGHTS_ON_IS_VALID & (0x01U)) << 1) | ((_m->MOOD_LIGHTS_ON_IS_VALID & (0x01U)) << 2) | ((_m->DIM_LEVEL_IS_VALID & (0x01U)) << 3);
+
+  *_len = INTERIOR_LIGHTS_RPT_DLC;
+  *_ide = INTERIOR_LIGHTS_RPT_IDE;
+  return INTERIOR_LIGHTS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->DRIVER_DOOR_OPEN = (_d[0] & (0x01U));
+  _m->PASS_DOOR_OPEN = ((_d[0] >> 1) & (0x01U));
+  _m->REAR_DRIVER_DOOR_OPEN = ((_d[0] >> 2) & (0x01U));
+  _m->REAR_PASS_DOOR_OPEN = ((_d[0] >> 3) & (0x01U));
+  _m->HOOD_OPEN = ((_d[0] >> 4) & (0x01U));
+  _m->TRUNK_OPEN = ((_d[0] >> 5) & (0x01U));
+  _m->FUEL_DOOR_OPEN = ((_d[0] >> 6) & (0x01U));
+  _m->DRIVER_DOOR_OPEN_IS_VALID = (_d[1] & (0x01U));
+  _m->PASS_DOOR_OPEN_IS_VALID = ((_d[1] >> 1) & (0x01U));
+  _m->REAR_DRIVER_DOOR_OPEN_IS_VALID = ((_d[1] >> 2) & (0x01U));
+  _m->REAR_PASS_DOOR_OPEN_IS_VALID = ((_d[1] >> 3) & (0x01U));
+  _m->HOOD_OPEN_IS_VALID = ((_d[1] >> 4) & (0x01U));
+  _m->TRUNK_OPEN_IS_VALID = ((_d[1] >> 5) & (0x01U));
+  _m->FUEL_DOOR_OPEN_IS_VALID = ((_d[1] >> 6) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < DOOR_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_DOOR_RPT_pacmod5(&_m->mon1, DOOR_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return DOOR_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < DOOR_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->DRIVER_DOOR_OPEN & (0x01U)) | ((_m->PASS_DOOR_OPEN & (0x01U)) << 1) | ((_m->REAR_DRIVER_DOOR_OPEN & (0x01U)) << 2) | ((_m->REAR_PASS_DOOR_OPEN & (0x01U)) << 3) | ((_m->HOOD_OPEN & (0x01U)) << 4) | ((_m->TRUNK_OPEN & (0x01U)) << 5) | ((_m->FUEL_DOOR_OPEN & (0x01U)) << 6);
+  cframe->Data[1] |= (_m->DRIVER_DOOR_OPEN_IS_VALID & (0x01U)) | ((_m->PASS_DOOR_OPEN_IS_VALID & (0x01U)) << 1) | ((_m->REAR_DRIVER_DOOR_OPEN_IS_VALID & (0x01U)) << 2) | ((_m->REAR_PASS_DOOR_OPEN_IS_VALID & (0x01U)) << 3) | ((_m->HOOD_OPEN_IS_VALID & (0x01U)) << 4) | ((_m->TRUNK_OPEN_IS_VALID & (0x01U)) << 5) | ((_m->FUEL_DOOR_OPEN_IS_VALID & (0x01U)) << 6);
+
+  cframe->MsgId = DOOR_RPT_CANID;
+  cframe->DLC = DOOR_RPT_DLC;
+  cframe->IDE = DOOR_RPT_IDE;
+  return DOOR_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < DOOR_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->DRIVER_DOOR_OPEN & (0x01U)) | ((_m->PASS_DOOR_OPEN & (0x01U)) << 1) | ((_m->REAR_DRIVER_DOOR_OPEN & (0x01U)) << 2) | ((_m->REAR_PASS_DOOR_OPEN & (0x01U)) << 3) | ((_m->HOOD_OPEN & (0x01U)) << 4) | ((_m->TRUNK_OPEN & (0x01U)) << 5) | ((_m->FUEL_DOOR_OPEN & (0x01U)) << 6);
+  _d[1] |= (_m->DRIVER_DOOR_OPEN_IS_VALID & (0x01U)) | ((_m->PASS_DOOR_OPEN_IS_VALID & (0x01U)) << 1) | ((_m->REAR_DRIVER_DOOR_OPEN_IS_VALID & (0x01U)) << 2) | ((_m->REAR_PASS_DOOR_OPEN_IS_VALID & (0x01U)) << 3) | ((_m->HOOD_OPEN_IS_VALID & (0x01U)) << 4) | ((_m->TRUNK_OPEN_IS_VALID & (0x01U)) << 5) | ((_m->FUEL_DOOR_OPEN_IS_VALID & (0x01U)) << 6);
+
+  *_len = DOOR_RPT_DLC;
+  *_ide = DOOR_RPT_IDE;
+  return DOOR_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->BRAKE_LIGHTS_ON = (_d[0] & (0x01U));
+  _m->REVERSE_LIGHTS_ON = ((_d[0] >> 1) & (0x01U));
+  _m->BRAKE_LIGHTS_ON_IS_VALID = (_d[1] & (0x01U));
+  _m->REVERSE_LIGHTS_ON_IS_VALID = ((_d[1] >> 1) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < REAR_LIGHTS_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_REAR_LIGHTS_RPT_pacmod5(&_m->mon1, REAR_LIGHTS_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return REAR_LIGHTS_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < REAR_LIGHTS_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->BRAKE_LIGHTS_ON & (0x01U)) | ((_m->REVERSE_LIGHTS_ON & (0x01U)) << 1);
+  cframe->Data[1] |= (_m->BRAKE_LIGHTS_ON_IS_VALID & (0x01U)) | ((_m->REVERSE_LIGHTS_ON_IS_VALID & (0x01U)) << 1);
+
+  cframe->MsgId = REAR_LIGHTS_RPT_CANID;
+  cframe->DLC = REAR_LIGHTS_RPT_DLC;
+  cframe->IDE = REAR_LIGHTS_RPT_IDE;
+  return REAR_LIGHTS_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < REAR_LIGHTS_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->BRAKE_LIGHTS_ON & (0x01U)) | ((_m->REVERSE_LIGHTS_ON & (0x01U)) << 1);
+  _d[1] |= (_m->BRAKE_LIGHTS_ON_IS_VALID & (0x01U)) | ((_m->REVERSE_LIGHTS_ON_IS_VALID & (0x01U)) << 1);
+
+  *_len = REAR_LIGHTS_RPT_DLC;
+  *_ide = REAR_LIGHTS_RPT_IDE;
+  return REAR_LIGHTS_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->LATERAL_NEW_DATA_RX = (_d[0] & (0x01U));
+  _m->LONGITUDNAL_NEW_DATA_RX = ((_d[0] >> 1) & (0x01U));
+  _m->VERTICAL_NEW_DATA_RX = ((_d[0] >> 2) & (0x01U));
+  _m->LATERAL_VALID = ((_d[0] >> 3) & (0x01U));
+  _m->LONGITUDNAL_VALID = ((_d[0] >> 4) & (0x01U));
+  _m->VERTICAL_VALID = ((_d[0] >> 5) & (0x01U));
+  _m->LATERAL_ACCEL_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LATERAL_ACCEL_phys = (sigfloat_t)(PACMOD5_LATERAL_ACCEL_ro_fromS(_m->LATERAL_ACCEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->LONGITUDNAL_ACCEL_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LONGITUDNAL_ACCEL_phys = (sigfloat_t)(PACMOD5_LONGITUDNAL_ACCEL_ro_fromS(_m->LONGITUDNAL_ACCEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->VERTICAL_ACCEL_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->VERTICAL_ACCEL_phys = (sigfloat_t)(PACMOD5_VERTICAL_ACCEL_ro_fromS(_m->VERTICAL_ACCEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < LINEAR_ACCEL_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_LINEAR_ACCEL_RPT_pacmod5(&_m->mon1, LINEAR_ACCEL_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return LINEAR_ACCEL_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < LINEAR_ACCEL_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LATERAL_ACCEL_ro = PACMOD5_LATERAL_ACCEL_ro_toS(_m->LATERAL_ACCEL_phys);
+  _m->LONGITUDNAL_ACCEL_ro = PACMOD5_LONGITUDNAL_ACCEL_ro_toS(_m->LONGITUDNAL_ACCEL_phys);
+  _m->VERTICAL_ACCEL_ro = PACMOD5_VERTICAL_ACCEL_ro_toS(_m->VERTICAL_ACCEL_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->LATERAL_NEW_DATA_RX & (0x01U)) | ((_m->LONGITUDNAL_NEW_DATA_RX & (0x01U)) << 1) | ((_m->VERTICAL_NEW_DATA_RX & (0x01U)) << 2) | ((_m->LATERAL_VALID & (0x01U)) << 3) | ((_m->LONGITUDNAL_VALID & (0x01U)) << 4) | ((_m->VERTICAL_VALID & (0x01U)) << 5);
+  cframe->Data[1] |= ((_m->LATERAL_ACCEL_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->LATERAL_ACCEL_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->LONGITUDNAL_ACCEL_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->LONGITUDNAL_ACCEL_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->VERTICAL_ACCEL_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->VERTICAL_ACCEL_ro & (0xFFU));
+
+  cframe->MsgId = LINEAR_ACCEL_RPT_CANID;
+  cframe->DLC = LINEAR_ACCEL_RPT_DLC;
+  cframe->IDE = LINEAR_ACCEL_RPT_IDE;
+  return LINEAR_ACCEL_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < LINEAR_ACCEL_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->LATERAL_ACCEL_ro = PACMOD5_LATERAL_ACCEL_ro_toS(_m->LATERAL_ACCEL_phys);
+  _m->LONGITUDNAL_ACCEL_ro = PACMOD5_LONGITUDNAL_ACCEL_ro_toS(_m->LONGITUDNAL_ACCEL_phys);
+  _m->VERTICAL_ACCEL_ro = PACMOD5_VERTICAL_ACCEL_ro_toS(_m->VERTICAL_ACCEL_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->LATERAL_NEW_DATA_RX & (0x01U)) | ((_m->LONGITUDNAL_NEW_DATA_RX & (0x01U)) << 1) | ((_m->VERTICAL_NEW_DATA_RX & (0x01U)) << 2) | ((_m->LATERAL_VALID & (0x01U)) << 3) | ((_m->LONGITUDNAL_VALID & (0x01U)) << 4) | ((_m->VERTICAL_VALID & (0x01U)) << 5);
+  _d[1] |= ((_m->LATERAL_ACCEL_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->LATERAL_ACCEL_ro & (0xFFU));
+  _d[3] |= ((_m->LONGITUDNAL_ACCEL_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->LONGITUDNAL_ACCEL_ro & (0xFFU));
+  _d[5] |= ((_m->VERTICAL_ACCEL_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->VERTICAL_ACCEL_ro & (0xFFU));
+
+  *_len = LINEAR_ACCEL_RPT_DLC;
+  *_ide = LINEAR_ACCEL_RPT_IDE;
+  return LINEAR_ACCEL_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->PITCH_NEW_DATA_RX = (_d[0] & (0x01U));
+  _m->ROLL_NEW_DATA_RX = ((_d[0] >> 1) & (0x01U));
+  _m->YAW_NEW_DATA_RX = ((_d[0] >> 2) & (0x01U));
+  _m->PITCH_VALID = ((_d[0] >> 3) & (0x01U));
+  _m->ROLL_VALID = ((_d[0] >> 4) & (0x01U));
+  _m->YAW_VALID = ((_d[0] >> 5) & (0x01U));
+  _m->PITCH_VEL_ro = __ext_sig__(( ((_d[1] & (0xFFU)) << 8) | (_d[2] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->PITCH_VEL_phys = (sigfloat_t)(PACMOD5_PITCH_VEL_ro_fromS(_m->PITCH_VEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->ROLL_VEL_ro = __ext_sig__(( ((_d[3] & (0xFFU)) << 8) | (_d[4] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->ROLL_VEL_phys = (sigfloat_t)(PACMOD5_ROLL_VEL_ro_fromS(_m->ROLL_VEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _m->YAW_VEL_ro = __ext_sig__(( ((_d[5] & (0xFFU)) << 8) | (_d[6] & (0xFFU)) ), 16);
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->YAW_VEL_phys = (sigfloat_t)(PACMOD5_YAW_VEL_ro_fromS(_m->YAW_VEL_ro));
+#endif // PACMOD5_USE_SIGFLOAT
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ANG_VEL_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ANG_VEL_RPT_pacmod5(&_m->mon1, ANG_VEL_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ANG_VEL_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ANG_VEL_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->PITCH_VEL_ro = PACMOD5_PITCH_VEL_ro_toS(_m->PITCH_VEL_phys);
+  _m->ROLL_VEL_ro = PACMOD5_ROLL_VEL_ro_toS(_m->ROLL_VEL_phys);
+  _m->YAW_VEL_ro = PACMOD5_YAW_VEL_ro_toS(_m->YAW_VEL_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  cframe->Data[0] |= (_m->PITCH_NEW_DATA_RX & (0x01U)) | ((_m->ROLL_NEW_DATA_RX & (0x01U)) << 1) | ((_m->YAW_NEW_DATA_RX & (0x01U)) << 2) | ((_m->PITCH_VALID & (0x01U)) << 3) | ((_m->ROLL_VALID & (0x01U)) << 4) | ((_m->YAW_VALID & (0x01U)) << 5);
+  cframe->Data[1] |= ((_m->PITCH_VEL_ro >> 8) & (0xFFU));
+  cframe->Data[2] |= (_m->PITCH_VEL_ro & (0xFFU));
+  cframe->Data[3] |= ((_m->ROLL_VEL_ro >> 8) & (0xFFU));
+  cframe->Data[4] |= (_m->ROLL_VEL_ro & (0xFFU));
+  cframe->Data[5] |= ((_m->YAW_VEL_ro >> 8) & (0xFFU));
+  cframe->Data[6] |= (_m->YAW_VEL_ro & (0xFFU));
+
+  cframe->MsgId = ANG_VEL_RPT_CANID;
+  cframe->DLC = ANG_VEL_RPT_DLC;
+  cframe->IDE = ANG_VEL_RPT_IDE;
+  return ANG_VEL_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ANG_VEL_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  _m->PITCH_VEL_ro = PACMOD5_PITCH_VEL_ro_toS(_m->PITCH_VEL_phys);
+  _m->ROLL_VEL_ro = PACMOD5_ROLL_VEL_ro_toS(_m->ROLL_VEL_phys);
+  _m->YAW_VEL_ro = PACMOD5_YAW_VEL_ro_toS(_m->YAW_VEL_phys);
+#endif // PACMOD5_USE_SIGFLOAT
+
+  _d[0] |= (_m->PITCH_NEW_DATA_RX & (0x01U)) | ((_m->ROLL_NEW_DATA_RX & (0x01U)) << 1) | ((_m->YAW_NEW_DATA_RX & (0x01U)) << 2) | ((_m->PITCH_VALID & (0x01U)) << 3) | ((_m->ROLL_VALID & (0x01U)) << 4) | ((_m->YAW_VALID & (0x01U)) << 5);
+  _d[1] |= ((_m->PITCH_VEL_ro >> 8) & (0xFFU));
+  _d[2] |= (_m->PITCH_VEL_ro & (0xFFU));
+  _d[3] |= ((_m->ROLL_VEL_ro >> 8) & (0xFFU));
+  _d[4] |= (_m->ROLL_VEL_ro & (0xFFU));
+  _d[5] |= ((_m->YAW_VEL_ro >> 8) & (0xFFU));
+  _d[6] |= (_m->YAW_VEL_ro & (0xFFU));
+
+  *_len = ANG_VEL_RPT_DLC;
+  *_ide = ANG_VEL_RPT_IDE;
+  return ANG_VEL_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->BUZZER_MUTE = (_d[0] & (0x01U));
+  _m->UNDERDASH_LIGHTS_WHITE = ((_d[0] >> 1) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < NOTIFICATION_CMD_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_NOTIFICATION_CMD_pacmod5(&_m->mon1, NOTIFICATION_CMD_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return NOTIFICATION_CMD_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < NOTIFICATION_CMD_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->BUZZER_MUTE & (0x01U)) | ((_m->UNDERDASH_LIGHTS_WHITE & (0x01U)) << 1);
+
+  cframe->MsgId = NOTIFICATION_CMD_CANID;
+  cframe->DLC = NOTIFICATION_CMD_DLC;
+  cframe->IDE = NOTIFICATION_CMD_IDE;
+  return NOTIFICATION_CMD_CANID;
+}
+
+#else
+
+uint32_t Pack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < NOTIFICATION_CMD_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->BUZZER_MUTE & (0x01U)) | ((_m->UNDERDASH_LIGHTS_WHITE & (0x01U)) << 1);
+
+  *_len = NOTIFICATION_CMD_DLC;
+  *_ide = NOTIFICATION_CMD_IDE;
+  return NOTIFICATION_CMD_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->ESTOP = (_d[0] & (0x01U));
+  _m->ESTOP_FAULT = ((_d[0] >> 1) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < ESTOP_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_ESTOP_RPT_pacmod5(&_m->mon1, ESTOP_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return ESTOP_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < ESTOP_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->ESTOP & (0x01U)) | ((_m->ESTOP_FAULT & (0x01U)) << 1);
+
+  cframe->MsgId = ESTOP_RPT_CANID;
+  cframe->DLC = ESTOP_RPT_DLC;
+  cframe->IDE = ESTOP_RPT_IDE;
+  return ESTOP_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < ESTOP_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->ESTOP & (0x01U)) | ((_m->ESTOP_FAULT & (0x01U)) << 1);
+
+  *_len = ESTOP_RPT_DLC;
+  *_ide = ESTOP_RPT_IDE;
+  return ESTOP_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, const uint8_t* _d, uint8_t dlc_)
+{
+  (void)dlc_;
+  _m->GLOBAL_ENABLE_FLAG = (_d[0] & (0x01U));
+  _m->GLOBAL_OVERRIDE_ACTIVE = ((_d[0] >> 1) & (0x01U));
+  _m->GLOBAL_COMMAND_TIMEOUT_ERROR = ((_d[0] >> 2) & (0x01U));
+  _m->GLOBAL_PACMOD_SUBSYSTEM_TIMEOUT = ((_d[0] >> 3) & (0x01U));
+  _m->GLOBAL_VEHICLE_CAN_TIMEOUT = ((_d[0] >> 4) & (0x01U));
+  _m->GLOBAL_PACMOD_SYSTEM_FAULT_ACTIVE = ((_d[0] >> 5) & (0x01U));
+  _m->GLOBAL_CONFIG_FAULT_ACTIVE = ((_d[0] >> 6) & (0x01U));
+  _m->GLOBAL_TIMEOUT = ((_d[0] >> 7) & (0x01U));
+  _m->ACCEL_ENABLED = (_d[1] & (0x01U));
+  _m->ACCEL_OVERRIDE_ACTIVE = ((_d[1] >> 1) & (0x01U));
+  _m->ACCEL_COMMAND_OUTPUT_FAULT = ((_d[1] >> 2) & (0x01U));
+  _m->ACCEL_INPUT_OUTPUT_FAULT = ((_d[1] >> 3) & (0x01U));
+  _m->ACCEL_OUTPUT_REPORTED_FAULT = ((_d[1] >> 4) & (0x01U));
+  _m->ACCEL_PACMOD_FAULT = ((_d[1] >> 5) & (0x01U));
+  _m->ACCEL_VEHICLE_FAULT = ((_d[1] >> 6) & (0x01U));
+  _m->ACCEL_TIMEOUT = ((_d[1] >> 7) & (0x01U));
+  _m->BRAKE_ENABLED = (_d[2] & (0x01U));
+  _m->BRAKE_OVERRIDE_ACTIVE = ((_d[2] >> 1) & (0x01U));
+  _m->BRAKE_COMMAND_OUTPUT_FAULT = ((_d[2] >> 2) & (0x01U));
+  _m->BRAKE_INPUT_OUTPUT_FAULT = ((_d[2] >> 3) & (0x01U));
+  _m->BRAKE_OUTPUT_REPORTED_FAULT = ((_d[2] >> 4) & (0x01U));
+  _m->BRAKE_PACMOD_FAULT = ((_d[2] >> 5) & (0x01U));
+  _m->BRAKE_VEHICLE_FAULT = ((_d[2] >> 6) & (0x01U));
+  _m->BRAKE_TIMEOUT = ((_d[2] >> 7) & (0x01U));
+  _m->SHIFT_ENABLED = (_d[3] & (0x01U));
+  _m->SHIFT_OVERRIDE_ACTIVE = ((_d[3] >> 1) & (0x01U));
+  _m->SHIFT_COMMAND_OUTPUT_FAULT = ((_d[3] >> 2) & (0x01U));
+  _m->SHIFT_INPUT_OUTPUT_FAULT = ((_d[3] >> 3) & (0x01U));
+  _m->SHIFT_OUTPUT_REPORTED_FAULT = ((_d[3] >> 4) & (0x01U));
+  _m->SHIFT_PACMOD_FAULT = ((_d[3] >> 5) & (0x01U));
+  _m->SHIFT_VEHICLE_FAULT = ((_d[3] >> 6) & (0x01U));
+  _m->SHIFT_TIMEOUT = ((_d[3] >> 7) & (0x01U));
+  _m->STEER_ENABLED = (_d[4] & (0x01U));
+  _m->STEER_OVERRIDE_ACTIVE = ((_d[4] >> 1) & (0x01U));
+  _m->STEER_COMMAND_OUTPUT_FAULT = ((_d[4] >> 2) & (0x01U));
+  _m->STEER_INPUT_OUTPUT_FAULT = ((_d[4] >> 3) & (0x01U));
+  _m->STEER_OUTPUT_REPORTED_FAULT = ((_d[4] >> 4) & (0x01U));
+  _m->STEER_PACMOD_FAULT = ((_d[4] >> 5) & (0x01U));
+  _m->STEER_VEHICLE_FAULT = ((_d[4] >> 6) & (0x01U));
+  _m->STEER_TIMEOUT = ((_d[4] >> 7) & (0x01U));
+  _m->MOD1_CONFIG_FAULT = (_d[5] & (0x01U));
+  _m->MOD1_CAN_TIMEOUT = ((_d[5] >> 1) & (0x01U));
+  _m->MOD1_COUNTER_FAULT = ((_d[5] >> 2) & (0x01U));
+  _m->MOD2_CONFIG_FAULT = ((_d[5] >> 3) & (0x01U));
+  _m->MOD2_CAN_TIMEOUT = ((_d[5] >> 4) & (0x01U));
+  _m->MOD2_COUNTER_FAULT = ((_d[5] >> 5) & (0x01U));
+  _m->MOD3_CONFIG_FAULT = ((_d[5] >> 6) & (0x01U));
+  _m->MOD3_CAN_TIMEOUT = ((_d[5] >> 7) & (0x01U));
+  _m->MOD3_COUNTER_FAULT = (_d[6] & (0x01U));
+  _m->MINI1_RPT_TIMEOUT = ((_d[6] >> 1) & (0x01U));
+  _m->MINI1_CONFIG_FAULT = ((_d[6] >> 2) & (0x01U));
+  _m->MINI1_CAN_TIMEOUT = ((_d[6] >> 3) & (0x01U));
+  _m->MINI1_COUNTER_FAULT = ((_d[6] >> 4) & (0x01U));
+  _m->MINI2_RPT_TIMEOUT = ((_d[6] >> 5) & (0x01U));
+  _m->MINI2_CONFIG_FAULT = ((_d[6] >> 6) & (0x01U));
+  _m->MINI2_CAN_TIMEOUT = ((_d[6] >> 7) & (0x01U));
+  _m->MINI2_COUNTER_FAULT = (_d[7] & (0x01U));
+  _m->MINI3_RPT_TIMEOUT = ((_d[7] >> 1) & (0x01U));
+  _m->MINI3_CONFIG_FAULT = ((_d[7] >> 2) & (0x01U));
+  _m->MINI3_CAN_TIMEOUT = ((_d[7] >> 3) & (0x01U));
+  _m->MINI3_COUNTER_FAULT = ((_d[7] >> 4) & (0x01U));
+  _m->MOD_SYSTEM_PRESENT_FAULT = ((_d[7] >> 5) & (0x01U));
+  _m->MINI_SYSTEM_PRESENT_FAULT = ((_d[7] >> 6) & (0x01U));
+  _m->GLOBAL_INTERNAL_POWER_SUPPLY_FAULT = ((_d[7] >> 7) & (0x01U));
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+  _m->mon1.dlc_error = (dlc_ < WATCHDOG_RPT_DLC);
+  _m->mon1.last_cycle = GetSystemTick();
+  _m->mon1.frame_cnt++;
+
+  FMon_WATCHDOG_RPT_pacmod5(&_m->mon1, WATCHDOG_RPT_CANID);
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+  return WATCHDOG_RPT_CANID;
+}
+
+#ifdef PACMOD5_USE_CANSTRUCT
+
+uint32_t Pack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, __CoderDbcCanFrame_t__* cframe)
+{
+  uint8_t i; for (i = 0; (i < WATCHDOG_RPT_DLC) && (i < 8); cframe->Data[i++] = 0);
+
+  cframe->Data[0] |= (_m->GLOBAL_ENABLE_FLAG & (0x01U)) | ((_m->GLOBAL_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->GLOBAL_COMMAND_TIMEOUT_ERROR & (0x01U)) << 2) | ((_m->GLOBAL_PACMOD_SUBSYSTEM_TIMEOUT & (0x01U)) << 3) | ((_m->GLOBAL_VEHICLE_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->GLOBAL_PACMOD_SYSTEM_FAULT_ACTIVE & (0x01U)) << 5) | ((_m->GLOBAL_CONFIG_FAULT_ACTIVE & (0x01U)) << 6) | ((_m->GLOBAL_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[1] |= (_m->ACCEL_ENABLED & (0x01U)) | ((_m->ACCEL_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->ACCEL_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->ACCEL_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->ACCEL_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->ACCEL_PACMOD_FAULT & (0x01U)) << 5) | ((_m->ACCEL_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->ACCEL_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[2] |= (_m->BRAKE_ENABLED & (0x01U)) | ((_m->BRAKE_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->BRAKE_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->BRAKE_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->BRAKE_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->BRAKE_PACMOD_FAULT & (0x01U)) << 5) | ((_m->BRAKE_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->BRAKE_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[3] |= (_m->SHIFT_ENABLED & (0x01U)) | ((_m->SHIFT_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->SHIFT_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->SHIFT_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->SHIFT_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->SHIFT_PACMOD_FAULT & (0x01U)) << 5) | ((_m->SHIFT_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->SHIFT_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[4] |= (_m->STEER_ENABLED & (0x01U)) | ((_m->STEER_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->STEER_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->STEER_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->STEER_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->STEER_PACMOD_FAULT & (0x01U)) << 5) | ((_m->STEER_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->STEER_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[5] |= (_m->MOD1_CONFIG_FAULT & (0x01U)) | ((_m->MOD1_CAN_TIMEOUT & (0x01U)) << 1) | ((_m->MOD1_COUNTER_FAULT & (0x01U)) << 2) | ((_m->MOD2_CONFIG_FAULT & (0x01U)) << 3) | ((_m->MOD2_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->MOD2_COUNTER_FAULT & (0x01U)) << 5) | ((_m->MOD3_CONFIG_FAULT & (0x01U)) << 6) | ((_m->MOD3_CAN_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[6] |= (_m->MOD3_COUNTER_FAULT & (0x01U)) | ((_m->MINI1_RPT_TIMEOUT & (0x01U)) << 1) | ((_m->MINI1_CONFIG_FAULT & (0x01U)) << 2) | ((_m->MINI1_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->MINI1_COUNTER_FAULT & (0x01U)) << 4) | ((_m->MINI2_RPT_TIMEOUT & (0x01U)) << 5) | ((_m->MINI2_CONFIG_FAULT & (0x01U)) << 6) | ((_m->MINI2_CAN_TIMEOUT & (0x01U)) << 7);
+  cframe->Data[7] |= (_m->MINI2_COUNTER_FAULT & (0x01U)) | ((_m->MINI3_RPT_TIMEOUT & (0x01U)) << 1) | ((_m->MINI3_CONFIG_FAULT & (0x01U)) << 2) | ((_m->MINI3_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->MINI3_COUNTER_FAULT & (0x01U)) << 4) | ((_m->MOD_SYSTEM_PRESENT_FAULT & (0x01U)) << 5) | ((_m->MINI_SYSTEM_PRESENT_FAULT & (0x01U)) << 6) | ((_m->GLOBAL_INTERNAL_POWER_SUPPLY_FAULT & (0x01U)) << 7);
+
+  cframe->MsgId = WATCHDOG_RPT_CANID;
+  cframe->DLC = WATCHDOG_RPT_DLC;
+  cframe->IDE = WATCHDOG_RPT_IDE;
+  return WATCHDOG_RPT_CANID;
+}
+
+#else
+
+uint32_t Pack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide)
+{
+  uint8_t i; for (i = 0; (i < WATCHDOG_RPT_DLC) && (i < 8); _d[i++] = 0);
+
+  _d[0] |= (_m->GLOBAL_ENABLE_FLAG & (0x01U)) | ((_m->GLOBAL_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->GLOBAL_COMMAND_TIMEOUT_ERROR & (0x01U)) << 2) | ((_m->GLOBAL_PACMOD_SUBSYSTEM_TIMEOUT & (0x01U)) << 3) | ((_m->GLOBAL_VEHICLE_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->GLOBAL_PACMOD_SYSTEM_FAULT_ACTIVE & (0x01U)) << 5) | ((_m->GLOBAL_CONFIG_FAULT_ACTIVE & (0x01U)) << 6) | ((_m->GLOBAL_TIMEOUT & (0x01U)) << 7);
+  _d[1] |= (_m->ACCEL_ENABLED & (0x01U)) | ((_m->ACCEL_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->ACCEL_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->ACCEL_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->ACCEL_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->ACCEL_PACMOD_FAULT & (0x01U)) << 5) | ((_m->ACCEL_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->ACCEL_TIMEOUT & (0x01U)) << 7);
+  _d[2] |= (_m->BRAKE_ENABLED & (0x01U)) | ((_m->BRAKE_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->BRAKE_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->BRAKE_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->BRAKE_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->BRAKE_PACMOD_FAULT & (0x01U)) << 5) | ((_m->BRAKE_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->BRAKE_TIMEOUT & (0x01U)) << 7);
+  _d[3] |= (_m->SHIFT_ENABLED & (0x01U)) | ((_m->SHIFT_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->SHIFT_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->SHIFT_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->SHIFT_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->SHIFT_PACMOD_FAULT & (0x01U)) << 5) | ((_m->SHIFT_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->SHIFT_TIMEOUT & (0x01U)) << 7);
+  _d[4] |= (_m->STEER_ENABLED & (0x01U)) | ((_m->STEER_OVERRIDE_ACTIVE & (0x01U)) << 1) | ((_m->STEER_COMMAND_OUTPUT_FAULT & (0x01U)) << 2) | ((_m->STEER_INPUT_OUTPUT_FAULT & (0x01U)) << 3) | ((_m->STEER_OUTPUT_REPORTED_FAULT & (0x01U)) << 4) | ((_m->STEER_PACMOD_FAULT & (0x01U)) << 5) | ((_m->STEER_VEHICLE_FAULT & (0x01U)) << 6) | ((_m->STEER_TIMEOUT & (0x01U)) << 7);
+  _d[5] |= (_m->MOD1_CONFIG_FAULT & (0x01U)) | ((_m->MOD1_CAN_TIMEOUT & (0x01U)) << 1) | ((_m->MOD1_COUNTER_FAULT & (0x01U)) << 2) | ((_m->MOD2_CONFIG_FAULT & (0x01U)) << 3) | ((_m->MOD2_CAN_TIMEOUT & (0x01U)) << 4) | ((_m->MOD2_COUNTER_FAULT & (0x01U)) << 5) | ((_m->MOD3_CONFIG_FAULT & (0x01U)) << 6) | ((_m->MOD3_CAN_TIMEOUT & (0x01U)) << 7);
+  _d[6] |= (_m->MOD3_COUNTER_FAULT & (0x01U)) | ((_m->MINI1_RPT_TIMEOUT & (0x01U)) << 1) | ((_m->MINI1_CONFIG_FAULT & (0x01U)) << 2) | ((_m->MINI1_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->MINI1_COUNTER_FAULT & (0x01U)) << 4) | ((_m->MINI2_RPT_TIMEOUT & (0x01U)) << 5) | ((_m->MINI2_CONFIG_FAULT & (0x01U)) << 6) | ((_m->MINI2_CAN_TIMEOUT & (0x01U)) << 7);
+  _d[7] |= (_m->MINI2_COUNTER_FAULT & (0x01U)) | ((_m->MINI3_RPT_TIMEOUT & (0x01U)) << 1) | ((_m->MINI3_CONFIG_FAULT & (0x01U)) << 2) | ((_m->MINI3_CAN_TIMEOUT & (0x01U)) << 3) | ((_m->MINI3_COUNTER_FAULT & (0x01U)) << 4) | ((_m->MOD_SYSTEM_PRESENT_FAULT & (0x01U)) << 5) | ((_m->MINI_SYSTEM_PRESENT_FAULT & (0x01U)) << 6) | ((_m->GLOBAL_INTERNAL_POWER_SUPPLY_FAULT & (0x01U)) << 7);
+
+  *_len = WATCHDOG_RPT_DLC;
+  *_ide = WATCHDOG_RPT_IDE;
+  return WATCHDOG_RPT_CANID;
+}
+
+#endif // PACMOD5_USE_CANSTRUCT
+

--- a/src/autogen/pacmod5.h
+++ b/src/autogen/pacmod5.h
@@ -1,0 +1,7027 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+// DBC file version
+#define VER_PACMOD5_MAJ (0U)
+#define VER_PACMOD5_MIN (0U)
+
+// include current dbc-driver compilation config
+#include "pacmod5-config.h"
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+// This file must define:
+// base monitor struct
+// function signature for HASH calculation: (@GetFrameHash)
+// function signature for getting system tick value: (@GetSystemTick)
+#include "canmonitorutil.h"
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+
+// def @GLOBAL_RPT CAN Message (16   0x10)
+#define GLOBAL_RPT_IDE (0U)
+#define GLOBAL_RPT_DLC (8U)
+#define GLOBAL_RPT_CANID (0x10)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "Control Disabled"
+  //  1 : "Control Enabled"
+  uint8_t PACMOD_SYSTEM_ENABLED : 1;           //      Bits= 1
+
+  //  0 : "Not Overridden"
+  //  1 : "Overridden"
+  uint8_t PACMOD_SYSTEM_OVERRIDE_ACTIVE : 1;   //      Bits= 1
+
+  uint8_t USR_CAN_TIMEOUT : 1;                 //      Bits= 1
+
+  uint8_t STR_CAN_TIMEOUT : 1;                 //      Bits= 1
+
+  //  0 : "No Active CAN Timeout"
+  //  1 : "Active CAN Timeout"
+  uint8_t BRK_CAN_TIMEOUT : 1;                 //      Bits= 1
+
+  uint8_t PACMOD_SUBSYSTEM_TIMEOUT : 1;        //      Bits= 1
+
+  uint8_t VEH_CAN_TIMEOUT : 1;                 //      Bits= 1
+
+  uint8_t PACMOD_SYSTEM_FAULT_ACTIVE : 1;      //      Bits= 1
+
+  uint8_t CONFIG_FAULT_ACTIVE : 1;             //      Bits= 1
+
+  uint16_t USR_CAN_READ_ERRORS;                //      Bits=16
+
+#else
+
+  //  0 : "Control Disabled"
+  //  1 : "Control Enabled"
+  uint8_t PACMOD_SYSTEM_ENABLED;               //      Bits= 1
+
+  //  0 : "Not Overridden"
+  //  1 : "Overridden"
+  uint8_t PACMOD_SYSTEM_OVERRIDE_ACTIVE;       //      Bits= 1
+
+  uint8_t USR_CAN_TIMEOUT;                     //      Bits= 1
+
+  uint8_t STR_CAN_TIMEOUT;                     //      Bits= 1
+
+  //  0 : "No Active CAN Timeout"
+  //  1 : "Active CAN Timeout"
+  uint8_t BRK_CAN_TIMEOUT;                     //      Bits= 1
+
+  uint8_t PACMOD_SUBSYSTEM_TIMEOUT;            //      Bits= 1
+
+  uint8_t VEH_CAN_TIMEOUT;                     //      Bits= 1
+
+  uint8_t PACMOD_SYSTEM_FAULT_ACTIVE;          //      Bits= 1
+
+  uint8_t CONFIG_FAULT_ACTIVE;                 //      Bits= 1
+
+  uint16_t USR_CAN_READ_ERRORS;                //      Bits=16
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} GLOBAL_RPT_t;
+
+// def @COMPONENT_RPT_00 CAN Message (32   0x20)
+#define COMPONENT_RPT_00_IDE (0U)
+#define COMPONENT_RPT_00_DLC (8U)
+#define COMPONENT_RPT_00_CANID (0x20)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE : 4;                  //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS : 1;          //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT : 1;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT : 1;             //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT : 1;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS : 1;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT : 1;                           //      Bits= 1
+
+  uint8_t SPRAY : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING : 1;                        //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG : 1;                        //      Bits= 1
+
+  uint8_t BRAKE_DECCEL : 1;                    //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER : 4;                         //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT : 4;                      //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT : 1;   //      Bits= 1
+
+#else
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE;                      //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT;                 //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS;                      //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT;                               //      Bits= 1
+
+  uint8_t SPRAY;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG;                            //      Bits= 1
+
+  uint8_t BRAKE_DECCEL;                        //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER;                             //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT;                          //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT;       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} COMPONENT_RPT_00_t;
+
+// def @COMPONENT_RPT_01 CAN Message (33   0x21)
+#define COMPONENT_RPT_01_IDE (0U)
+#define COMPONENT_RPT_01_DLC (8U)
+#define COMPONENT_RPT_01_CANID (0x21)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE : 4;                  //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS : 1;          //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT : 1;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT : 1;             //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT : 1;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS : 1;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT : 1;                           //      Bits= 1
+
+  uint8_t SPRAY : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING : 1;                        //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG : 1;                        //      Bits= 1
+
+  uint8_t BRAKE_DECCEL : 1;                    //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER : 4;                         //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT : 4;                      //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT : 1;   //      Bits= 1
+
+#else
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE;                      //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT;                 //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS;                      //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT;                               //      Bits= 1
+
+  uint8_t SPRAY;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG;                            //      Bits= 1
+
+  uint8_t BRAKE_DECCEL;                        //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER;                             //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT;                          //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT;       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} COMPONENT_RPT_01_t;
+
+// def @COMPONENT_RPT_02 CAN Message (34   0x22)
+#define COMPONENT_RPT_02_IDE (0U)
+#define COMPONENT_RPT_02_DLC (8U)
+#define COMPONENT_RPT_02_CANID (0x22)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE : 4;                  //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS : 1;          //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT : 1;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT : 1;             //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT : 1;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS : 1;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT : 1;                           //      Bits= 1
+
+  uint8_t SPRAY : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING : 1;                        //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG : 1;                        //      Bits= 1
+
+  uint8_t BRAKE_DECCEL : 1;                    //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER : 4;                         //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT : 4;                      //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT : 1;   //      Bits= 1
+
+#else
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE;                      //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT;                 //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS;                      //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT;                               //      Bits= 1
+
+  uint8_t SPRAY;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG;                            //      Bits= 1
+
+  uint8_t BRAKE_DECCEL;                        //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER;                             //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT;                          //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT;       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} COMPONENT_RPT_02_t;
+
+// def @COMPONENT_RPT_03 CAN Message (35   0x23)
+#define COMPONENT_RPT_03_IDE (0U)
+#define COMPONENT_RPT_03_DLC (8U)
+#define COMPONENT_RPT_03_CANID (0x23)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE : 4;                  //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS : 1;          //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT : 1;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT : 1;             //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT : 1;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS : 1;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE : 1;                   //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT : 1;                           //      Bits= 1
+
+  uint8_t SPRAY : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING : 1;                        //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN : 1;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER : 1;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG : 1;                        //      Bits= 1
+
+  uint8_t BRAKE_DECCEL : 1;                    //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER : 4;                         //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT : 4;                      //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT : 1;   //      Bits= 1
+
+#else
+
+  //  0 : "PACMod"
+  //  1 : "PACMini"
+  //  2 : "PACMicro"
+  uint8_t COMPONENT_TYPE;                      //      Bits= 4
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t ACCEL;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t BRAKE;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t CRUISE_CONTROL_BUTTONS;              //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_LEFT;                  //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t DASH_CONTROLS_RIGHT;                 //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HAZARD_LIGHTS;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HEADLIGHT;                           //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t HORN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t MEDIA_CONTROLS;                      //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t PARKING_BRAKE;                       //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t SHIFT;                               //      Bits= 1
+
+  uint8_t SPRAY;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t STEERING;                            //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t TURN;                                //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WIPER;                               //      Bits= 1
+
+  //  0 : "ABSENT"
+  //  1 : "PRESENT"
+  uint8_t WATCHDOG;                            //      Bits= 1
+
+  uint8_t BRAKE_DECCEL;                        //      Bits= 1
+
+  // Counter shall have the value of 0 with the first message transmission.  It shall increase by 1 with each subsequent message transmission up to and including the value of 0xF.  The next message transmission shall be 0, and this pattern shall repeat.
+  uint8_t COUNTER;                             //      Bits= 4
+
+  // The COMPLEMENT shall be the complement of the COUNTER.  For example, if COUNTER is 0x1011, then the COMPLEMENT is 0x0100.
+  uint8_t COMPLEMENT;                          //      Bits= 4
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t CAN_TIMEOUT_FAULT;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INTERNAL_SUPPLY_VOLTAGE_FAULT;       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} COMPONENT_RPT_03_t;
+
+// def @GLOBAL_CMD CAN Message (128  0x80)
+#define GLOBAL_CMD_IDE (0U)
+#define GLOBAL_CMD_DLC (8U)
+#define GLOBAL_CMD_CANID (0x80)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t CLEAR_FAULTS : 1;                  //      Bits= 1
+
+#else
+
+  uint8_t CLEAR_FAULTS;                      //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} GLOBAL_CMD_t;
+
+// def @ACCEL_CMD CAN Message (256  0x100)
+#define ACCEL_CMD_IDE (0U)
+#define ACCEL_CMD_DLC (8U)
+#define ACCEL_CMD_CANID (0x100)
+// signal: @ACCEL_CMD_ro
+#define PACMOD5_ACCEL_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_ACCEL_CMD_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ACCEL_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  uint16_t ACCEL_CMD_ro;                     //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ACCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  uint16_t ACCEL_CMD_ro;                     //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ACCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ACCEL_CMD_t;
+
+// def @BRAKE_CMD CAN Message (260  0x104)
+#define BRAKE_CMD_IDE (0U)
+#define BRAKE_CMD_DLC (8U)
+#define BRAKE_CMD_CANID (0x104)
+// signal: @BRAKE_CMD_ro
+#define PACMOD5_BRAKE_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_BRAKE_CMD_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_BRAKE_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  uint16_t BRAKE_CMD_ro;                     //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  uint16_t BRAKE_CMD_ro;                     //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_CMD_t;
+
+// def @CRUISE_CONTROL_BUTTONS_CMD CAN Message (264  0x108)
+#define CRUISE_CONTROL_BUTTONS_CMD_IDE (0U)
+#define CRUISE_CONTROL_BUTTONS_CMD_DLC (8U)
+#define CRUISE_CONTROL_BUTTONS_CMD_CANID (0x108)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t CRUISE_CONTROL_BUTTON;             //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t CRUISE_CONTROL_BUTTON;             //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} CRUISE_CONTROL_BUTTONS_CMD_t;
+
+// def @DASH_CONTROLS_LEFT_CMD CAN Message (268  0x10c)
+#define DASH_CONTROLS_LEFT_CMD_IDE (0U)
+#define DASH_CONTROLS_LEFT_CMD_DLC (8U)
+#define DASH_CONTROLS_LEFT_CMD_CANID (0x10c)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DASH_CONTROLS_LEFT_CMD_t;
+
+// def @DASH_CONTROLS_RIGHT_CMD CAN Message (272  0x110)
+#define DASH_CONTROLS_RIGHT_CMD_IDE (0U)
+#define DASH_CONTROLS_RIGHT_CMD_DLC (8U)
+#define DASH_CONTROLS_RIGHT_CMD_CANID (0x110)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t DASH_CONTROLS_BUTTON;              //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DASH_CONTROLS_RIGHT_CMD_t;
+
+// def @HAZARD_LIGHTS_CMD CAN Message (276  0x114)
+#define HAZARD_LIGHTS_CMD_IDE (0U)
+#define HAZARD_LIGHTS_CMD_DLC (8U)
+#define HAZARD_LIGHTS_CMD_CANID (0x114)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  uint8_t HAZARD_LIGHTS_CMD : 1;             //      Bits= 1
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  uint8_t HAZARD_LIGHTS_CMD;                 //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HAZARD_LIGHTS_CMD_t;
+
+// def @HEADLIGHT_CMD CAN Message (280  0x118)
+#define HEADLIGHT_CMD_IDE (0U)
+#define HEADLIGHT_CMD_DLC (8U)
+#define HEADLIGHT_CMD_CANID (0x118)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t HEADLIGHT_CMD;                     //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t HEADLIGHT_CMD;                     //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HEADLIGHT_CMD_t;
+
+// def @HORN_CMD CAN Message (284  0x11c)
+#define HORN_CMD_IDE (0U)
+#define HORN_CMD_DLC (8U)
+#define HORN_CMD_CANID (0x11c)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t HORN_CMD : 1;                      //      Bits= 1
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t HORN_CMD;                          //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HORN_CMD_t;
+
+// def @MEDIA_CONTROLS_CMD CAN Message (288  0x120)
+#define MEDIA_CONTROLS_CMD_IDE (0U)
+#define MEDIA_CONTROLS_CMD_DLC (8U)
+#define MEDIA_CONTROLS_CMD_CANID (0x120)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t MEDIA_CONTROLS_CMD;                //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t MEDIA_CONTROLS_CMD;                //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} MEDIA_CONTROLS_CMD_t;
+
+// def @PARKING_BRAKE_CMD CAN Message (292  0x124)
+#define PARKING_BRAKE_CMD_IDE (0U)
+#define PARKING_BRAKE_CMD_DLC (8U)
+#define PARKING_BRAKE_CMD_CANID (0x124)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  uint8_t PARKING_BRAKE_CMD : 1;             //      Bits= 1
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  uint8_t PARKING_BRAKE_CMD;                 //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} PARKING_BRAKE_CMD_t;
+
+// def @SHIFT_CMD CAN Message (296  0x128)
+#define SHIFT_CMD_IDE (0U)
+#define SHIFT_CMD_DLC (8U)
+#define SHIFT_CMD_CANID (0x128)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  // FORWARD is also HIGH on vehicles with LOW/HIGH, PARK and LOW only available on certain Vehicles.
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  7 : "NONE"
+  uint8_t SHIFT_CMD;                         //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  // FORWARD is also HIGH on vehicles with LOW/HIGH, PARK and LOW only available on certain Vehicles.
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  7 : "NONE"
+  uint8_t SHIFT_CMD;                         //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SHIFT_CMD_t;
+
+// def @STEERING_CMD CAN Message (300  0x12c)
+#define STEERING_CMD_IDE (0U)
+#define STEERING_CMD_DLC (8U)
+#define STEERING_CMD_CANID (0x12c)
+// signal: @POSITION_ro
+#define PACMOD5_POSITION_ro_CovFactor (0.001000)
+#define PACMOD5_POSITION_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_POSITION_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @ROTATION_RATE_ro
+#define PACMOD5_ROTATION_RATE_ro_CovFactor (0.001000)
+#define PACMOD5_ROTATION_RATE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ROTATION_RATE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  int16_t POSITION_ro;                       //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_ro;                 //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  int16_t POSITION_ro;                       //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_ro;                 //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_CMD_t;
+
+// def @TURN_CMD CAN Message (304  0x130)
+#define TURN_CMD_IDE (0U)
+#define TURN_CMD_DLC (8U)
+#define TURN_CMD_CANID (0x130)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t TURN_SIGNAL_CMD;                   //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t TURN_SIGNAL_CMD;                   //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} TURN_CMD_t;
+
+// def @WIPER_CMD CAN Message (308  0x134)
+#define WIPER_CMD_IDE (0U)
+#define WIPER_CMD_DLC (8U)
+#define WIPER_CMD_CANID (0x134)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t WIPER_CMD;                         //      Bits= 8
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t WIPER_CMD;                         //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} WIPER_CMD_t;
+
+// def @SPRAYER_CMD CAN Message (312  0x138)
+#define SPRAYER_CMD_IDE (0U)
+#define SPRAYER_CMD_DLC (8U)
+#define SPRAYER_CMD_CANID (0x138)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  //  0 : "NOT_SPRAYING"
+  //  1 : "SPRAYING"
+  uint8_t SPRAYER_CMD : 1;                   //      Bits= 1
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  //  0 : "NOT_SPRAYING"
+  //  1 : "SPRAYING"
+  uint8_t SPRAYER_CMD;                       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SPRAYER_CMD_t;
+
+// def @BRAKE_DECCEL_CMD CAN Message (316  0x13c)
+#define BRAKE_DECCEL_CMD_IDE (0U)
+#define BRAKE_DECCEL_CMD_DLC (8U)
+#define BRAKE_DECCEL_CMD_CANID (0x13c)
+// signal: @BRAKE_DECCEL_CMD_ro
+#define PACMOD5_BRAKE_DECCEL_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_BRAKE_DECCEL_CMD_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_BRAKE_DECCEL_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLE : 1;                        //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES : 1;              //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE : 1;                //      Bits= 1
+
+  uint16_t BRAKE_DECCEL_CMD_ro;              //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_DECCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  //  0 : "NO_ENDURANCE_BRAKE_INTEGRATION_ALLOWED"
+  //  1 : "ONLY_ENDURANCE_BRAKES_ALLOWED"
+  //  2 : "ENDURANCE_BRAKE_INTEGRATION_ALLOWED"
+  uint8_t XBR_EBI_MODE : 2;                  //      Bits= 2
+
+  //  0 : "HIGHEST_PRIORITY"
+  //  1 : "HIGH_PRIORITY"
+  //  2 : "MEDIUM_PRIORITY"
+  //  3 : "LOW_PRIORITY"
+  uint8_t XBR_PRIORITY : 2;                  //      Bits= 2
+
+  //  0 : "OVERRIDE_DISABLE"
+  //  1 : "ACCELERATION_CONTROL_WITH_ADDITION_MODE"
+  //  2 : "ACCELERATION_CONTROL_WITH_MAXIMUM_MODE"
+  uint8_t XBR_CONTROL_MODE : 2;              //      Bits= 2
+
+#else
+
+  uint8_t ENABLE;                            //      Bits= 1
+
+  uint8_t IGNORE_OVERRIDES;                  //      Bits= 1
+
+  uint8_t CLEAR_OVERRIDE;                    //      Bits= 1
+
+  uint16_t BRAKE_DECCEL_CMD_ro;              //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_DECCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  //  0 : "NO_ENDURANCE_BRAKE_INTEGRATION_ALLOWED"
+  //  1 : "ONLY_ENDURANCE_BRAKES_ALLOWED"
+  //  2 : "ENDURANCE_BRAKE_INTEGRATION_ALLOWED"
+  uint8_t XBR_EBI_MODE;                      //      Bits= 2
+
+  //  0 : "HIGHEST_PRIORITY"
+  //  1 : "HIGH_PRIORITY"
+  //  2 : "MEDIUM_PRIORITY"
+  //  3 : "LOW_PRIORITY"
+  uint8_t XBR_PRIORITY;                      //      Bits= 2
+
+  //  0 : "OVERRIDE_DISABLE"
+  //  1 : "ACCELERATION_CONTROL_WITH_ADDITION_MODE"
+  //  2 : "ACCELERATION_CONTROL_WITH_MAXIMUM_MODE"
+  uint8_t XBR_CONTROL_MODE;                  //      Bits= 2
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_DECCEL_CMD_t;
+
+// def @ACCEL_RPT CAN Message (512  0x200)
+#define ACCEL_RPT_IDE (0U)
+#define ACCEL_RPT_DLC (8U)
+#define ACCEL_RPT_CANID (0x200)
+// signal: @MANUAL_INPUT_ro
+#define PACMOD5_MANUAL_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_MANUAL_INPUT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MANUAL_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @COMMANDED_VALUE_ro
+#define PACMOD5_COMMANDED_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_COMMANDED_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_COMMANDED_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @OUTPUT_VALUE_ro
+#define PACMOD5_OUTPUT_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_OUTPUT_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_OUTPUT_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ACCEL_RPT_t;
+
+// def @ACCEL_CMD_LIMIT_RPT CAN Message (513  0x201)
+#define ACCEL_CMD_LIMIT_RPT_IDE (0U)
+#define ACCEL_CMD_LIMIT_RPT_DLC (8U)
+#define ACCEL_CMD_LIMIT_RPT_CANID (0x201)
+// signal: @ACCEL_CMD_LIMIT_ro
+#define PACMOD5_ACCEL_CMD_LIMIT_ro_CovFactor (0.001000)
+#define PACMOD5_ACCEL_CMD_LIMIT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ACCEL_CMD_LIMIT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @LIMITED_ACCEL_CMD_ro
+#define PACMOD5_LIMITED_ACCEL_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_LIMITED_ACCEL_CMD_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_LIMITED_ACCEL_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint16_t ACCEL_CMD_LIMIT_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ACCEL_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_ACCEL_CMD_ro;             //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_ACCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint16_t ACCEL_CMD_LIMIT_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ACCEL_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_ACCEL_CMD_ro;             //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_ACCEL_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ACCEL_CMD_LIMIT_RPT_t;
+
+// def @BRAKE_RPT CAN Message (516  0x204)
+#define BRAKE_RPT_IDE (0U)
+#define BRAKE_RPT_DLC (8U)
+#define BRAKE_RPT_CANID (0x204)
+// signal: @MANUAL_INPUT_ro
+#define PACMOD5_MANUAL_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_MANUAL_INPUT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MANUAL_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @COMMANDED_VALUE_ro
+#define PACMOD5_COMMANDED_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_COMMANDED_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_COMMANDED_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @OUTPUT_VALUE_ro
+#define PACMOD5_OUTPUT_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_OUTPUT_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_OUTPUT_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_RPT_t;
+
+// def @BRAKE_CMD_LIMIT_RPT CAN Message (517  0x205)
+#define BRAKE_CMD_LIMIT_RPT_IDE (0U)
+#define BRAKE_CMD_LIMIT_RPT_DLC (8U)
+#define BRAKE_CMD_LIMIT_RPT_CANID (0x205)
+// signal: @BRAKE_CMD_LIMIT_ro
+#define PACMOD5_BRAKE_CMD_LIMIT_ro_CovFactor (0.001000)
+#define PACMOD5_BRAKE_CMD_LIMIT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_BRAKE_CMD_LIMIT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @LIMITED_BRAKE_CMD_ro
+#define PACMOD5_LIMITED_BRAKE_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_LIMITED_BRAKE_CMD_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_LIMITED_BRAKE_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint16_t BRAKE_CMD_LIMIT_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_BRAKE_CMD_ro;             //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_BRAKE_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint16_t BRAKE_CMD_LIMIT_ro;               //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t BRAKE_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_BRAKE_CMD_ro;             //      Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_BRAKE_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_CMD_LIMIT_RPT_t;
+
+// def @CRUISE_CONTROL_BUTTONS_RPT CAN Message (520  0x208)
+#define CRUISE_CONTROL_BUTTONS_RPT_IDE (0U)
+#define CRUISE_CONTROL_BUTTONS_RPT_DLC (8U)
+#define CRUISE_CONTROL_BUTTONS_RPT_CANID (0x208)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  6 : "CRUISE_CONTROL_ON_OFF"
+  //  5 : "CRUISE_CONTROL_RES_INC"
+  //  4 : "CRUISE_CONTROL_SET_DEC"
+  //  3 : "CRUISE_CONTROL_ACC_CLOSER"
+  //  2 : "CRUISE_CONTROL_ACC_FURTHER"
+  //  1 : "CRUISE_CONTROL_CNCL"
+  //  0 : "CRUISE_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} CRUISE_CONTROL_BUTTONS_RPT_t;
+
+// def @DASH_CONTROLS_LEFT_RPT CAN Message (524  0x20c)
+#define DASH_CONTROLS_LEFT_RPT_IDE (0U)
+#define DASH_CONTROLS_LEFT_RPT_DLC (8U)
+#define DASH_CONTROLS_LEFT_RPT_CANID (0x20c)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DASH_CONTROLS_LEFT_RPT_t;
+
+// def @DASH_CONTROLS_RIGHT_RPT CAN Message (528  0x210)
+#define DASH_CONTROLS_RIGHT_RPT_IDE (0U)
+#define DASH_CONTROLS_RIGHT_RPT_DLC (8U)
+#define DASH_CONTROLS_RIGHT_RPT_CANID (0x210)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  5 : "DASH_CONTROL_DOWN"
+  //  4 : "DASH_CONTROL_UP"
+  //  3 : "DASH_CONTROL_RIGHT"
+  //  2 : "DASH_CONTROL_LEFT"
+  //  1 : "DASH_CONTROL_OK"
+  //  0 : "DASH_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DASH_CONTROLS_RIGHT_RPT_t;
+
+// def @HAZARD_LIGHTS_RPT CAN Message (532  0x214)
+#define HAZARD_LIGHTS_RPT_IDE (0U)
+#define HAZARD_LIGHTS_RPT_DLC (8U)
+#define HAZARD_LIGHTS_RPT_CANID (0x214)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint8_t MANUAL_INPUT : 1;                  //      Bits= 1
+
+  uint8_t COMMANDED_VALUE : 1;               //      Bits= 1
+
+  uint8_t OUTPUT_VALUE : 1;                  //      Bits= 1
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint8_t MANUAL_INPUT;                      //      Bits= 1
+
+  uint8_t COMMANDED_VALUE;                   //      Bits= 1
+
+  uint8_t OUTPUT_VALUE;                      //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HAZARD_LIGHTS_RPT_t;
+
+// def @HEADLIGHT_RPT CAN Message (536  0x218)
+#define HEADLIGHT_RPT_IDE (0U)
+#define HEADLIGHT_RPT_DLC (8U)
+#define HEADLIGHT_RPT_CANID (0x218)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  2 : "High Beams"
+  //  1 : "Low Beams"
+  //  0 : "Headlights Off"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HEADLIGHT_RPT_t;
+
+// def @HORN_RPT CAN Message (540  0x21c)
+#define HORN_RPT_IDE (0U)
+#define HORN_RPT_DLC (8U)
+#define HORN_RPT_CANID (0x21c)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "OFF"
+  //  1 : "ON"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HORN_RPT_t;
+
+// def @MEDIA_CONTROLS_RPT CAN Message (544  0x220)
+#define MEDIA_CONTROLS_RPT_IDE (0U)
+#define MEDIA_CONTROLS_RPT_DLC (8U)
+#define MEDIA_CONTROLS_RPT_CANID (0x220)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  6 : "MEDIA_CONTROL_VOL_DOWN"
+  //  5 : "MEDIA_CONTROL_VOL_UP"
+  //  4 : "MEDIA_CONTROL_NEXT_TRACK_HANG_UP"
+  //  3 : "MEDIA_CONTROL_PREV_TRACK_ANSWER"
+  //  2 : "MEDIA_CONTROL_MUTE"
+  //  1 : "MEDIA_CONTROL_VOICE_COMMAND"
+  //  0 : "MEDIA_CONTROL_NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} MEDIA_CONTROLS_RPT_t;
+
+// def @PARKING_BRAKE_RPT CAN Message (548  0x224)
+#define PARKING_BRAKE_RPT_IDE (0U)
+#define PARKING_BRAKE_RPT_DLC (8U)
+#define PARKING_BRAKE_RPT_CANID (0x224)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint8_t MANUAL_INPUT : 1;                  //      Bits= 1
+
+  uint8_t COMMANDED_VALUE : 1;               //      Bits= 1
+
+  uint8_t OUTPUT_VALUE : 1;                  //      Bits= 1
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint8_t MANUAL_INPUT;                      //      Bits= 1
+
+  uint8_t COMMANDED_VALUE;                   //      Bits= 1
+
+  uint8_t OUTPUT_VALUE;                      //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} PARKING_BRAKE_RPT_t;
+
+// def @SHIFT_RPT CAN Message (552  0x228)
+#define SHIFT_RPT_IDE (0U)
+#define SHIFT_RPT_DLC (8U)
+#define SHIFT_RPT_CANID (0x228)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  5 : "BETWEEN_GEARS"
+  //  6 : "ERROR"
+  //  7 : "NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  7 : "NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  5 : "BETWEEN_GEARS"
+  //  6 : "ERROR"
+  //  7 : "NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  5 : "BETWEEN_GEARS"
+  //  6 : "ERROR"
+  //  7 : "NONE"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  7 : "NONE"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "PARK"
+  //  1 : "REVERSE"
+  //  2 : "NEUTRAL"
+  //  3 : "FORWARD/HIGH"
+  //  4 : "LOW"
+  //  5 : "BETWEEN_GEARS"
+  //  6 : "ERROR"
+  //  7 : "NONE"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SHIFT_RPT_t;
+
+// def @STEERING_RPT CAN Message (556  0x22c)
+#define STEERING_RPT_IDE (0U)
+#define STEERING_RPT_DLC (8U)
+#define STEERING_RPT_CANID (0x22c)
+// signal: @MANUAL_INPUT_ro
+#define PACMOD5_MANUAL_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_MANUAL_INPUT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MANUAL_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @COMMANDED_VALUE_ro
+#define PACMOD5_COMMANDED_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_COMMANDED_VALUE_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_COMMANDED_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @OUTPUT_VALUE_ro
+#define PACMOD5_OUTPUT_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_OUTPUT_VALUE_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_OUTPUT_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  int16_t MANUAL_INPUT_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t COMMANDED_VALUE_ro;                //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t OUTPUT_VALUE_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  int16_t MANUAL_INPUT_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t COMMANDED_VALUE_ro;                //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t OUTPUT_VALUE_ro;                   //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_RPT_t;
+
+// def @STEERING_CMD_LIMIT_RPT CAN Message (557  0x22d)
+#define STEERING_CMD_LIMIT_RPT_IDE (0U)
+#define STEERING_CMD_LIMIT_RPT_DLC (8U)
+#define STEERING_CMD_LIMIT_RPT_CANID (0x22d)
+// signal: @POSITION_CMD_LIMIT_ro
+#define PACMOD5_POSITION_CMD_LIMIT_ro_CovFactor (0.001000)
+#define PACMOD5_POSITION_CMD_LIMIT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_POSITION_CMD_LIMIT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @LIMITED_POSITION_CMD_ro
+#define PACMOD5_LIMITED_POSITION_CMD_ro_CovFactor (0.001000)
+#define PACMOD5_LIMITED_POSITION_CMD_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_LIMITED_POSITION_CMD_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @ROTATION_RATE_CMD_LIMIT_ro
+#define PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_CovFactor (0.001000)
+#define PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ROTATION_RATE_CMD_LIMIT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @LIMITED_ROTATION_RATE_ro
+#define PACMOD5_LIMITED_ROTATION_RATE_ro_CovFactor (0.001000)
+#define PACMOD5_LIMITED_ROTATION_RATE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_LIMITED_ROTATION_RATE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t POSITION_CMD_LIMIT_ro;             //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t POSITION_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t LIMITED_POSITION_CMD_ro;           //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_POSITION_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_CMD_LIMIT_ro;       //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_ROTATION_RATE_ro;         //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int16_t POSITION_CMD_LIMIT_ro;             //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t POSITION_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t LIMITED_POSITION_CMD_ro;           //  [-] Bits=16 Factor= 0.001000        Unit:'rad'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_POSITION_CMD_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_CMD_LIMIT_ro;       //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_CMD_LIMIT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t LIMITED_ROTATION_RATE_ro;         //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LIMITED_ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_CMD_LIMIT_RPT_t;
+
+// def @TURN_RPT CAN Message (560  0x230)
+#define TURN_RPT_IDE (0U)
+#define TURN_RPT_DLC (8U)
+#define TURN_RPT_CANID (0x230)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  0 : "RIGHT"
+  //  1 : "NONE"
+  //  2 : "LEFT"
+  //  3 : "HAZARD"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} TURN_RPT_t;
+
+// def @WIPER_RPT CAN Message (564  0x234)
+#define WIPER_RPT_IDE (0U)
+#define WIPER_RPT_DLC (8U)
+#define WIPER_RPT_CANID (0x234)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  //  0 : "NO_TIMEOUT"
+  //  1 : "TIMEOUT"
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t MANUAL_INPUT;                      //      Bits= 8
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t COMMANDED_VALUE;                   //      Bits= 8
+
+  //  255 : "High"
+  //  254 : "Medium"
+  //  253 : "Low"
+  //  10 : "Intermittent 10"
+  //  9 : "Intermittent 9"
+  //  8 : "Intermittent 8"
+  //  7 : "Intermittent 7"
+  //  6 : "Intermittent 6"
+  //  5 : "Intermittent 5"
+  //  4 : "Intermittent 4"
+  //  3 : "Intermittent 3"
+  //  2 : "Intermittent 2"
+  //  1 : "Intermittent 1"
+  //  0 : "Wipers Off"
+  uint8_t OUTPUT_VALUE;                      //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} WIPER_RPT_t;
+
+// def @SPRAYER_RPT CAN Message (568  0x238)
+#define SPRAYER_RPT_IDE (0U)
+#define SPRAYER_RPT_DLC (8U)
+#define SPRAYER_RPT_CANID (0x238)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint8_t MANUAL_INPUT : 1;                  //      Bits= 1
+
+  uint8_t COMMANDED_VALUE : 1;               //      Bits= 1
+
+  uint8_t OUTPUT_VALUE : 1;                  //      Bits= 1
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint8_t MANUAL_INPUT;                      //      Bits= 1
+
+  uint8_t COMMANDED_VALUE;                   //      Bits= 1
+
+  uint8_t OUTPUT_VALUE;                      //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SPRAYER_RPT_t;
+
+// def @BRAKE_DECCEL_RPT CAN Message (572  0x23c)
+#define BRAKE_DECCEL_RPT_IDE (0U)
+#define BRAKE_DECCEL_RPT_DLC (8U)
+#define BRAKE_DECCEL_RPT_CANID (0x23c)
+// signal: @MANUAL_INPUT_ro
+#define PACMOD5_MANUAL_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_MANUAL_INPUT_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MANUAL_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @COMMANDED_VALUE_ro
+#define PACMOD5_COMMANDED_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_COMMANDED_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_COMMANDED_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @OUTPUT_VALUE_ro
+#define PACMOD5_OUTPUT_VALUE_ro_CovFactor (0.001000)
+#define PACMOD5_OUTPUT_VALUE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_OUTPUT_VALUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t ENABLED : 1;                       //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  uint8_t COMMAND_OUTPUT_FAULT : 1;          //      Bits= 1
+
+  uint8_t INPUT_OUTPUT_FAULT : 1;            //      Bits= 1
+
+  uint8_t OUTPUT_REPORTED_FAULT : 1;         //      Bits= 1
+
+  uint8_t PACMOD_FAULT : 1;                  //      Bits= 1
+
+  uint8_t VEHICLE_FAULT : 1;                 //      Bits= 1
+
+  uint8_t COMMAND_TIMEOUT : 1;               //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t ENABLED;                           //      Bits= 1
+
+  uint8_t OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  uint8_t COMMAND_OUTPUT_FAULT;              //      Bits= 1
+
+  uint8_t INPUT_OUTPUT_FAULT;                //      Bits= 1
+
+  uint8_t OUTPUT_REPORTED_FAULT;             //      Bits= 1
+
+  uint8_t PACMOD_FAULT;                      //      Bits= 1
+
+  uint8_t VEHICLE_FAULT;                     //      Bits= 1
+
+  uint8_t COMMAND_TIMEOUT;                   //      Bits= 1
+
+  uint16_t MANUAL_INPUT_ro;                  //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MANUAL_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t COMMANDED_VALUE_ro;               //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t COMMANDED_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t OUTPUT_VALUE_ro;                  //      Bits=16 Factor= 0.001000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t OUTPUT_VALUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_DECCEL_RPT_t;
+
+// def @ACCEL_AUX_RPT CAN Message (768  0x300)
+#define ACCEL_AUX_RPT_IDE (0U)
+#define ACCEL_AUX_RPT_DLC (8U)
+#define ACCEL_AUX_RPT_CANID (0x300)
+// signal: @RAW_PEDAL_POS_ro
+#define PACMOD5_RAW_PEDAL_POS_ro_CovFactor (0.001000)
+#define PACMOD5_RAW_PEDAL_POS_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_RAW_PEDAL_POS_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @RAW_PEDAL_FORCE_ro
+#define PACMOD5_RAW_PEDAL_FORCE_ro_CovFactor (0.001000)
+#define PACMOD5_RAW_PEDAL_FORCE_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_RAW_PEDAL_FORCE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t RAW_PEDAL_POS_ro;                  //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_PEDAL_POS_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t RAW_PEDAL_FORCE_ro;                //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_PEDAL_FORCE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION : 1;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_POS_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_FORCE_AVAIL : 1;         //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL : 1;    //      Bits= 1
+
+#else
+
+  int16_t RAW_PEDAL_POS_ro;                  //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_PEDAL_POS_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t RAW_PEDAL_FORCE_ro;                //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_PEDAL_FORCE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION;              //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_POS_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_FORCE_AVAIL;             //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL;        //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ACCEL_AUX_RPT_t;
+
+// def @BRAKE_AUX_RPT CAN Message (772  0x304)
+#define BRAKE_AUX_RPT_IDE (0U)
+#define BRAKE_AUX_RPT_DLC (8U)
+#define BRAKE_AUX_RPT_CANID (0x304)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t RAW_PEDAL_POS;                     //  [-] Bits=16
+
+  int16_t RAW_PEDAL_FORCE;                   //  [-] Bits=16
+
+  int16_t RAW_BRAKE_PRESSURE;                //  [-] Bits=16
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION : 1;          //      Bits= 1
+
+  uint8_t BRAKE_ON_OFF : 1;                  //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_POS_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_FORCE_AVAIL : 1;         //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_BRAKE_PRESSURE_AVAIL : 1;      //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL : 1;    //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BRAKE_ON_OFF_AVAIL : 1;            //      Bits= 1
+
+#else
+
+  int16_t RAW_PEDAL_POS;                     //  [-] Bits=16
+
+  int16_t RAW_PEDAL_FORCE;                   //  [-] Bits=16
+
+  int16_t RAW_BRAKE_PRESSURE;                //  [-] Bits=16
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION;              //      Bits= 1
+
+  uint8_t BRAKE_ON_OFF;                      //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_POS_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_PEDAL_FORCE_AVAIL;             //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_BRAKE_PRESSURE_AVAIL;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL;        //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BRAKE_ON_OFF_AVAIL;                //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_AUX_RPT_t;
+
+// def @HEADLIGHT_AUX_RPT CAN Message (792  0x318)
+#define HEADLIGHT_AUX_RPT_IDE (0U)
+#define HEADLIGHT_AUX_RPT_DLC (8U)
+#define HEADLIGHT_AUX_RPT_CANID (0x318)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t HEADLIGHTS_ON : 1;                 //      Bits= 1
+
+  uint8_t HEADLIGHTS_ON_BRIGHT : 1;          //      Bits= 1
+
+  uint8_t FOG_LIGHTS_ON : 1;                 //      Bits= 1
+
+  //  3 : "Headlights On - Auto Mode"
+  //  2 : "Headlights On - Manual Mode"
+  //  1 : "Parking Lights Only"
+  //  0 : "Headlights Off"
+  uint8_t HEADLIGHTS_MODE;                   //      Bits= 8
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_ON_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_ON_BRIGHT_AVAIL : 1;    //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FOG_LIGHTS_ON_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_MODE_AVAIL : 1;         //      Bits= 1
+
+#else
+
+  uint8_t HEADLIGHTS_ON;                     //      Bits= 1
+
+  uint8_t HEADLIGHTS_ON_BRIGHT;              //      Bits= 1
+
+  uint8_t FOG_LIGHTS_ON;                     //      Bits= 1
+
+  //  3 : "Headlights On - Auto Mode"
+  //  2 : "Headlights On - Manual Mode"
+  //  1 : "Parking Lights Only"
+  //  0 : "Headlights Off"
+  uint8_t HEADLIGHTS_MODE;                   //      Bits= 8
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_ON_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_ON_BRIGHT_AVAIL;        //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FOG_LIGHTS_ON_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HEADLIGHTS_MODE_AVAIL;             //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} HEADLIGHT_AUX_RPT_t;
+
+// def @SHIFT_AUX_RPT CAN Message (808  0x328)
+#define SHIFT_AUX_RPT_IDE (0U)
+#define SHIFT_AUX_RPT_DLC (8U)
+#define SHIFT_AUX_RPT_CANID (0x328)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t BETWEEN_GEARS : 1;                  //      Bits= 1
+
+  uint8_t STAY_IN_NEUTRAL_MODE : 1;           //      Bits= 1
+
+  uint8_t BRAKE_INTERLOCK_ACTIVE : 1;         //      Bits= 1
+
+  uint8_t SPEED_INTERLOCK_ACTIVE : 1;         //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BETWEEN_GEARS_AVAIL : 1;            //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t STAY_IN_NEUTRAL_MODE_AVAIL : 1;     //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BRAKE_INTERLOCK_ACTIVE_AVAIL : 1;   //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPEED_INTERLOCK_ACTIVE_AVAIL : 1;   //      Bits= 1
+
+  //  0 : "SILENT"
+  //  1 : "BEEP"
+  uint8_t WRITE_TO_CONFIG : 1;                //      Bits= 1
+
+#else
+
+  uint8_t BETWEEN_GEARS;                      //      Bits= 1
+
+  uint8_t STAY_IN_NEUTRAL_MODE;               //      Bits= 1
+
+  uint8_t BRAKE_INTERLOCK_ACTIVE;             //      Bits= 1
+
+  uint8_t SPEED_INTERLOCK_ACTIVE;             //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BETWEEN_GEARS_AVAIL;                //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t STAY_IN_NEUTRAL_MODE_AVAIL;         //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t BRAKE_INTERLOCK_ACTIVE_AVAIL;       //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPEED_INTERLOCK_ACTIVE_AVAIL;       //      Bits= 1
+
+  //  0 : "SILENT"
+  //  1 : "BEEP"
+  uint8_t WRITE_TO_CONFIG;                    //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SHIFT_AUX_RPT_t;
+
+// def @STEERING_AUX_RPT CAN Message (812  0x32c)
+#define STEERING_AUX_RPT_IDE (0U)
+#define STEERING_AUX_RPT_DLC (8U)
+#define STEERING_AUX_RPT_CANID (0x32c)
+// signal: @RAW_POSITION_ro
+#define PACMOD5_RAW_POSITION_ro_CovFactor (0.001000)
+#define PACMOD5_RAW_POSITION_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_RAW_POSITION_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @RAW_TORQUE_ro
+#define PACMOD5_RAW_TORQUE_ro_CovFactor (0.001000)
+#define PACMOD5_RAW_TORQUE_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_RAW_TORQUE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @ROTATION_RATE_ro
+#define PACMOD5_ROTATION_RATE_ro_CovFactor (0.001000)
+#define PACMOD5_ROTATION_RATE_ro_toS(x) ( (uint16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ROTATION_RATE_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t RAW_POSITION_ro;                   //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t RAW_TORQUE_ro;                     //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_TORQUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_ro;                 //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION : 1;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_POSITION_AVAIL : 1;            //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_TORQUE_AVAIL : 1;              //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t ROTATION_RATE_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL : 1;    //      Bits= 1
+
+#else
+
+  int16_t RAW_POSITION_ro;                   //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t RAW_TORQUE_ro;                     //  [-] Bits=16 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t RAW_TORQUE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint16_t ROTATION_RATE_ro;                 //      Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROTATION_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  // OPERATOR_INTERACTION shall have the value of 1 if the driver is moving, changing, or otherwise touching the operator control(s) that relates to this signal to an extent that is detectable. Otherwise, the value shall be 0.
+  //  0 : "NO_INTERACTION"
+  //  1 : "INTERACTION"
+  uint8_t OPERATOR_INTERACTION;              //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_POSITION_AVAIL;                //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t RAW_TORQUE_AVAIL;                  //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t ROTATION_RATE_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t OPERATOR_INTERACTION_AVAIL;        //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_AUX_RPT_t;
+
+// def @TURN_AUX_RPT CAN Message (816  0x330)
+#define TURN_AUX_RPT_IDE (0U)
+#define TURN_AUX_RPT_DLC (8U)
+#define TURN_AUX_RPT_CANID (0x330)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t DRIVER_BLINKER_BULB_ON : 1;         //      Bits= 1
+
+  uint8_t PASS_BLINKER_BULB_ON : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t DRIVER_BLINKER_BULB_ON_AVAIL : 1;   //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t PASS_BLINKER_BULB_ON_AVAIL : 1;     //      Bits= 1
+
+#else
+
+  uint8_t DRIVER_BLINKER_BULB_ON;             //      Bits= 1
+
+  uint8_t PASS_BLINKER_BULB_ON;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t DRIVER_BLINKER_BULB_ON_AVAIL;       //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t PASS_BLINKER_BULB_ON_AVAIL;         //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} TURN_AUX_RPT_t;
+
+// def @WIPER_AUX_RPT CAN Message (820  0x334)
+#define WIPER_AUX_RPT_IDE (0U)
+#define WIPER_AUX_RPT_DLC (8U)
+#define WIPER_AUX_RPT_CANID (0x334)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t FRONT_WIPING : 1;                  //      Bits= 1
+
+  uint8_t FRONT_SPRAYING : 1;                //      Bits= 1
+
+  uint8_t REAR_WIPING : 1;                   //      Bits= 1
+
+  uint8_t REAR_SPRAYING : 1;                 //      Bits= 1
+
+  uint8_t SPRAY_NEAR_EMPTY : 1;              //      Bits= 1
+
+  uint8_t SPRAY_EMPTY : 1;                   //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FRONT_WIPING_AVAIL : 1;            //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FRONT_SPRAYING_AVAIL : 1;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t REAR_WIPING_AVAIL : 1;             //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t REAR_SPRAYING_AVAIL : 1;           //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPRAY_NEAR_EMPTY_AVAIL : 1;        //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPRAY_EMPTY_AVAIL : 1;             //      Bits= 1
+
+#else
+
+  uint8_t FRONT_WIPING;                      //      Bits= 1
+
+  uint8_t FRONT_SPRAYING;                    //      Bits= 1
+
+  uint8_t REAR_WIPING;                       //      Bits= 1
+
+  uint8_t REAR_SPRAYING;                     //      Bits= 1
+
+  uint8_t SPRAY_NEAR_EMPTY;                  //      Bits= 1
+
+  uint8_t SPRAY_EMPTY;                       //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FRONT_WIPING_AVAIL;                //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FRONT_SPRAYING_AVAIL;              //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t REAR_WIPING_AVAIL;                 //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t REAR_SPRAYING_AVAIL;               //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPRAY_NEAR_EMPTY_AVAIL;            //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t SPRAY_EMPTY_AVAIL;                 //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} WIPER_AUX_RPT_t;
+
+// def @BRAKE_DECCEL_AUX_RPT CAN Message (824  0x338)
+#define BRAKE_DECCEL_AUX_RPT_IDE (0U)
+#define BRAKE_DECCEL_AUX_RPT_DLC (8U)
+#define BRAKE_DECCEL_AUX_RPT_CANID (0x338)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "NO_BRAKE_DEMAND"
+  //  1 : "DRIVERS_BRAKE_DEMAND"
+  //  2 : "ADDITION_MODE_OF_XBR_ACCELERATION_CONTROL"
+  //  3 : "MAXIMUM_MODE_OF_XBR_ACCELERATION_CONTROL"
+  uint8_t XBR_ACTIVE_CONTROL_MODE : 4;         //      Bits= 4
+
+  //  0 : "ANY_EXTERNAL_BRAKE_DEMAND_WILL_BE_ACCEPTED"
+  //  2 : "NO_EXTERNAL_BRAKE_DEMAND_WILL_BE_ACCEPTED"
+  uint8_t XBR_SYSTEM_STATE : 2;                //      Bits= 2
+
+  //  0 : "FOUNDATION_BRAKES_NOT_IN_USE"
+  //  1 : "FOUNDATION_BRAKES_IN_USE"
+  uint8_t FOUNDATION_BRAKE_USE : 2;            //      Bits= 2
+
+  //  0 : "INACTIVE"
+  //  1 : "ACTIVE"
+  //  2 : "ACTIVE_BUT_INACTIVE_SOON"
+  //  6 : "ERROR"
+  uint8_t HILL_HOLDER_MODE : 3;                //      Bits= 3
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t XBR_ACTIVE_CONTROL_MODE_AVAIL : 1;   //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t XBR_SYSTEM_STATE_AVAIL : 1;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FOUNDATION_BRAKE_USE_AVAIL : 1;      //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HILL_HOLDER_MODE_AVAIL : 1;          //      Bits= 1
+
+#else
+
+  //  0 : "NO_BRAKE_DEMAND"
+  //  1 : "DRIVERS_BRAKE_DEMAND"
+  //  2 : "ADDITION_MODE_OF_XBR_ACCELERATION_CONTROL"
+  //  3 : "MAXIMUM_MODE_OF_XBR_ACCELERATION_CONTROL"
+  uint8_t XBR_ACTIVE_CONTROL_MODE;             //      Bits= 4
+
+  //  0 : "ANY_EXTERNAL_BRAKE_DEMAND_WILL_BE_ACCEPTED"
+  //  2 : "NO_EXTERNAL_BRAKE_DEMAND_WILL_BE_ACCEPTED"
+  uint8_t XBR_SYSTEM_STATE;                    //      Bits= 2
+
+  //  0 : "FOUNDATION_BRAKES_NOT_IN_USE"
+  //  1 : "FOUNDATION_BRAKES_IN_USE"
+  uint8_t FOUNDATION_BRAKE_USE;                //      Bits= 2
+
+  //  0 : "INACTIVE"
+  //  1 : "ACTIVE"
+  //  2 : "ACTIVE_BUT_INACTIVE_SOON"
+  //  6 : "ERROR"
+  uint8_t HILL_HOLDER_MODE;                    //      Bits= 3
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t XBR_ACTIVE_CONTROL_MODE_AVAIL;       //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t XBR_SYSTEM_STATE_AVAIL;              //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t FOUNDATION_BRAKE_USE_AVAIL;          //      Bits= 1
+
+  // PACMod sets this value as a function of which vehicle platform is under test and, therefore, this value does not change during operation.
+  uint8_t HILL_HOLDER_MODE_AVAIL;              //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_DECCEL_AUX_RPT_t;
+
+// def @VEHICLE_SPEED_RPT CAN Message (1024 0x400)
+#define VEHICLE_SPEED_RPT_IDE (0U)
+#define VEHICLE_SPEED_RPT_DLC (8U)
+#define VEHICLE_SPEED_RPT_CANID (0x400)
+// signal: @VEHICLE_SPEED_ro
+#define PACMOD5_VEHICLE_SPEED_ro_CovFactor (0.010000)
+#define PACMOD5_VEHICLE_SPEED_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_VEHICLE_SPEED_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t VEHICLE_SPEED_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VEHICLE_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  //  0 : "INVALID"
+  //  1 : "VALID"
+  uint8_t VEHICLE_SPEED_VALID : 1;           //      Bits= 1
+
+#else
+
+  int16_t VEHICLE_SPEED_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VEHICLE_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  //  0 : "INVALID"
+  //  1 : "VALID"
+  uint8_t VEHICLE_SPEED_VALID;               //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} VEHICLE_SPEED_RPT_t;
+
+// def @BRAKE_MOTOR_RPT_1 CAN Message (1025 0x401)
+#define BRAKE_MOTOR_RPT_1_IDE (0U)
+#define BRAKE_MOTOR_RPT_1_DLC (8U)
+#define BRAKE_MOTOR_RPT_1_CANID (0x401)
+// signal: @MOTOR_CURRENT_ro
+#define PACMOD5_MOTOR_CURRENT_ro_CovFactor (0.001000)
+#define PACMOD5_MOTOR_CURRENT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MOTOR_CURRENT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @SHAFT_POSITION_ro
+#define PACMOD5_SHAFT_POSITION_ro_CovFactor (0.001000)
+#define PACMOD5_SHAFT_POSITION_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_SHAFT_POSITION_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int32_t MOTOR_CURRENT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'amps'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MOTOR_CURRENT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t SHAFT_POSITION_ro;                 //  [-] Bits=32 Factor= 0.001000        Unit:'radians'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t SHAFT_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int32_t MOTOR_CURRENT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'amps'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MOTOR_CURRENT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t SHAFT_POSITION_ro;                 //  [-] Bits=32 Factor= 0.001000        Unit:'radians'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t SHAFT_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_MOTOR_RPT_1_t;
+
+// def @BRAKE_MOTOR_RPT_2 CAN Message (1026 0x402)
+#define BRAKE_MOTOR_RPT_2_IDE (0U)
+#define BRAKE_MOTOR_RPT_2_DLC (8U)
+#define BRAKE_MOTOR_RPT_2_CANID (0x402)
+// signal: @ANGULAR_SPEED_ro
+#define PACMOD5_ANGULAR_SPEED_ro_CovFactor (0.100000)
+#define PACMOD5_ANGULAR_SPEED_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.100000)) )
+#define PACMOD5_ANGULAR_SPEED_ro_fromS(x) ( (((x) * (0.100000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t ENCODER_TEMPERATURE;               //  [-] Bits=16 Unit:'deg_C'
+
+  int16_t MOTOR_TEMPERATURE;                 //  [-] Bits=16 Unit:'deg_C'
+
+  int32_t ANGULAR_SPEED_ro;                  //  [-] Bits=32 Factor= 0.100000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ANGULAR_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int16_t ENCODER_TEMPERATURE;               //  [-] Bits=16 Unit:'deg_C'
+
+  int16_t MOTOR_TEMPERATURE;                 //  [-] Bits=16 Unit:'deg_C'
+
+  int32_t ANGULAR_SPEED_ro;                  //  [-] Bits=32 Factor= 0.100000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ANGULAR_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_MOTOR_RPT_2_t;
+
+// def @BRAKE_MOTOR_RPT_3 CAN Message (1027 0x403)
+#define BRAKE_MOTOR_RPT_3_IDE (0U)
+#define BRAKE_MOTOR_RPT_3_DLC (8U)
+#define BRAKE_MOTOR_RPT_3_CANID (0x403)
+// signal: @TORQUE_OUTPUT_ro
+#define PACMOD5_TORQUE_OUTPUT_ro_CovFactor (0.001000)
+#define PACMOD5_TORQUE_OUTPUT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_TORQUE_OUTPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @TORQUE_INPUT_ro
+#define PACMOD5_TORQUE_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_TORQUE_INPUT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_TORQUE_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int32_t TORQUE_OUTPUT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_OUTPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t TORQUE_INPUT_ro;                   //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int32_t TORQUE_OUTPUT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_OUTPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t TORQUE_INPUT_ro;                   //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} BRAKE_MOTOR_RPT_3_t;
+
+// def @STEERING_MOTOR_RPT_1 CAN Message (1028 0x404)
+#define STEERING_MOTOR_RPT_1_IDE (0U)
+#define STEERING_MOTOR_RPT_1_DLC (8U)
+#define STEERING_MOTOR_RPT_1_CANID (0x404)
+// signal: @MOTOR_CURRENT_ro
+#define PACMOD5_MOTOR_CURRENT_ro_CovFactor (0.001000)
+#define PACMOD5_MOTOR_CURRENT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_MOTOR_CURRENT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @SHAFT_POSITION_ro
+#define PACMOD5_SHAFT_POSITION_ro_CovFactor (0.001000)
+#define PACMOD5_SHAFT_POSITION_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_SHAFT_POSITION_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int32_t MOTOR_CURRENT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'amps'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MOTOR_CURRENT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t SHAFT_POSITION_ro;                 //  [-] Bits=32 Factor= 0.001000        Unit:'radians'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t SHAFT_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int32_t MOTOR_CURRENT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'amps'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t MOTOR_CURRENT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t SHAFT_POSITION_ro;                 //  [-] Bits=32 Factor= 0.001000        Unit:'radians'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t SHAFT_POSITION_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_MOTOR_RPT_1_t;
+
+// def @STEERING_MOTOR_RPT_2 CAN Message (1029 0x405)
+#define STEERING_MOTOR_RPT_2_IDE (0U)
+#define STEERING_MOTOR_RPT_2_DLC (8U)
+#define STEERING_MOTOR_RPT_2_CANID (0x405)
+// signal: @ANGULAR_SPEED_ro
+#define PACMOD5_ANGULAR_SPEED_ro_CovFactor (0.100000)
+#define PACMOD5_ANGULAR_SPEED_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.100000)) )
+#define PACMOD5_ANGULAR_SPEED_ro_fromS(x) ( (((x) * (0.100000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t ENCODER_TEMPERATURE;               //  [-] Bits=16 Unit:'deg_C'
+
+  int16_t MOTOR_TEMPERATURE;                 //  [-] Bits=16 Unit:'deg_C'
+
+  int32_t ANGULAR_SPEED_ro;                  //  [-] Bits=32 Factor= 0.100000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ANGULAR_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int16_t ENCODER_TEMPERATURE;               //  [-] Bits=16 Unit:'deg_C'
+
+  int16_t MOTOR_TEMPERATURE;                 //  [-] Bits=16 Unit:'deg_C'
+
+  int32_t ANGULAR_SPEED_ro;                  //  [-] Bits=32 Factor= 0.100000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ANGULAR_SPEED_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_MOTOR_RPT_2_t;
+
+// def @STEERING_MOTOR_RPT_3 CAN Message (1030 0x406)
+#define STEERING_MOTOR_RPT_3_IDE (0U)
+#define STEERING_MOTOR_RPT_3_DLC (8U)
+#define STEERING_MOTOR_RPT_3_CANID (0x406)
+// signal: @TORQUE_OUTPUT_ro
+#define PACMOD5_TORQUE_OUTPUT_ro_CovFactor (0.001000)
+#define PACMOD5_TORQUE_OUTPUT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_TORQUE_OUTPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @TORQUE_INPUT_ro
+#define PACMOD5_TORQUE_INPUT_ro_CovFactor (0.001000)
+#define PACMOD5_TORQUE_INPUT_ro_toS(x) ( (int32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_TORQUE_INPUT_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int32_t TORQUE_OUTPUT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_OUTPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t TORQUE_INPUT_ro;                   //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int32_t TORQUE_OUTPUT_ro;                  //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_OUTPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int32_t TORQUE_INPUT_ro;                   //  [-] Bits=32 Factor= 0.001000        Unit:'N-m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t TORQUE_INPUT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} STEERING_MOTOR_RPT_3_t;
+
+// def @WHEEL_SPEED_RPT CAN Message (1031 0x407)
+#define WHEEL_SPEED_RPT_IDE (0U)
+#define WHEEL_SPEED_RPT_DLC (8U)
+#define WHEEL_SPEED_RPT_CANID (0x407)
+// signal: @WHEEL_SPD_FRONT_LEFT_ro
+#define PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_CovFactor (0.010000)
+#define PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_WHEEL_SPD_FRONT_LEFT_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+// signal: @WHEEL_SPD_FRONT_RIGHT_ro
+#define PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_CovFactor (0.010000)
+#define PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_WHEEL_SPD_FRONT_RIGHT_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+// signal: @WHEEL_SPD_REAR_LEFT_ro
+#define PACMOD5_WHEEL_SPD_REAR_LEFT_ro_CovFactor (0.010000)
+#define PACMOD5_WHEEL_SPD_REAR_LEFT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_WHEEL_SPD_REAR_LEFT_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+// signal: @WHEEL_SPD_REAR_RIGHT_ro
+#define PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_CovFactor (0.010000)
+#define PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_WHEEL_SPD_REAR_RIGHT_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t WHEEL_SPD_FRONT_LEFT_ro;           //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_FRONT_LEFT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_FRONT_RIGHT_ro;          //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_FRONT_RIGHT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_REAR_LEFT_ro;            //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_REAR_LEFT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_REAR_RIGHT_ro;           //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_REAR_RIGHT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int16_t WHEEL_SPD_FRONT_LEFT_ro;           //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_FRONT_LEFT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_FRONT_RIGHT_ro;          //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_FRONT_RIGHT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_REAR_LEFT_ro;            //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_REAR_LEFT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t WHEEL_SPD_REAR_RIGHT_ro;           //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t WHEEL_SPD_REAR_RIGHT_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} WHEEL_SPEED_RPT_t;
+
+// def @SOFTWARE_VERSION_RPT_00 CAN Message (1032 0x408)
+#define SOFTWARE_VERSION_RPT_00_IDE (0U)
+#define SOFTWARE_VERSION_RPT_00_DLC (8U)
+#define SOFTWARE_VERSION_RPT_00_CANID (0x408)
+#define SOFTWARE_VERSION_RPT_00_CYC (1000U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#else
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SOFTWARE_VERSION_RPT_00_t;
+
+// def @SOFTWARE_VERSION_RPT_01 CAN Message (1033 0x409)
+#define SOFTWARE_VERSION_RPT_01_IDE (0U)
+#define SOFTWARE_VERSION_RPT_01_DLC (8U)
+#define SOFTWARE_VERSION_RPT_01_CANID (0x409)
+#define SOFTWARE_VERSION_RPT_01_CYC (1000U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#else
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SOFTWARE_VERSION_RPT_01_t;
+
+// def @SOFTWARE_VERSION_RPT_02 CAN Message (1034 0x40a)
+#define SOFTWARE_VERSION_RPT_02_IDE (0U)
+#define SOFTWARE_VERSION_RPT_02_DLC (8U)
+#define SOFTWARE_VERSION_RPT_02_CANID (0x40a)
+#define SOFTWARE_VERSION_RPT_02_CYC (1000U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#else
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SOFTWARE_VERSION_RPT_02_t;
+
+// def @SOFTWARE_VERSION_RPT_03 CAN Message (1035 0x40b)
+#define SOFTWARE_VERSION_RPT_03_IDE (0U)
+#define SOFTWARE_VERSION_RPT_03_DLC (8U)
+#define SOFTWARE_VERSION_RPT_03_CANID (0x40b)
+#define SOFTWARE_VERSION_RPT_03_CYC (1000U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#else
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MAJOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t MINOR;                             //      Bits= 8
+
+  // MAJOR, MINOR, and PATCH shall be the software version number and shall be defined by Sematic Versioning 2.0.  For build numbers other than 0000, it shall be the most recent software release.
+  uint8_t PATCH;                             //      Bits= 8
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD0;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD1;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD2;                            //      Bits= 8 Unit:'ASCII'
+
+  // BUILD0-BUILD3 shall represent the software build number and shall be constrained to characters A-Z and 0-9.
+  uint8_t BUILD3;                            //      Bits= 8 Unit:'ASCII'
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} SOFTWARE_VERSION_RPT_03_t;
+
+// def @YAW_RATE_RPT CAN Message (1037 0x40d)
+#define YAW_RATE_RPT_IDE (0U)
+#define YAW_RATE_RPT_DLC (8U)
+#define YAW_RATE_RPT_CANID (0x40d)
+// signal: @YAW_RATE_ro
+#define PACMOD5_YAW_RATE_ro_CovFactor (0.010000)
+#define PACMOD5_YAW_RATE_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_YAW_RATE_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int16_t YAW_RATE_ro;                       //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t YAW_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int16_t YAW_RATE_ro;                       //  [-] Bits=16 Factor= 0.010000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t YAW_RATE_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} YAW_RATE_RPT_t;
+
+// def @LAT_LON_HEADING_RPT CAN Message (1038 0x40e)
+#define LAT_LON_HEADING_RPT_IDE (0U)
+#define LAT_LON_HEADING_RPT_DLC (8U)
+#define LAT_LON_HEADING_RPT_CANID (0x40e)
+// signal: @HEADING_ro
+#define PACMOD5_HEADING_ro_CovFactor (0.010000)
+#define PACMOD5_HEADING_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_HEADING_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  int8_t LATITUDE_DEGREES;                   //  [-] Bits= 8 Unit:'deg'
+
+  int8_t LATITUDE_MINUTES;                   //  [-] Bits= 8 Unit:'min'
+
+  int8_t LATITUDE_SECONDS;                   //  [-] Bits= 8 Unit:'sec'
+
+  int8_t LONGITUDE_DEGREES;                  //  [-] Bits= 8 Unit:'deg'
+
+  int8_t LONGITUDE_MINUTES;                  //  [-] Bits= 8 Unit:'min'
+
+  int8_t LONGITUDE_SECONDS;                  //  [-] Bits= 8 Unit:'sec'
+
+  int16_t HEADING_ro;                        //  [-] Bits=16 Factor= 0.010000        Unit:'deg'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t HEADING_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  int8_t LATITUDE_DEGREES;                   //  [-] Bits= 8 Unit:'deg'
+
+  int8_t LATITUDE_MINUTES;                   //  [-] Bits= 8 Unit:'min'
+
+  int8_t LATITUDE_SECONDS;                   //  [-] Bits= 8 Unit:'sec'
+
+  int8_t LONGITUDE_DEGREES;                  //  [-] Bits= 8 Unit:'deg'
+
+  int8_t LONGITUDE_MINUTES;                  //  [-] Bits= 8 Unit:'min'
+
+  int8_t LONGITUDE_SECONDS;                  //  [-] Bits= 8 Unit:'sec'
+
+  int16_t HEADING_ro;                        //  [-] Bits=16 Factor= 0.010000        Unit:'deg'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t HEADING_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} LAT_LON_HEADING_RPT_t;
+
+// def @DATE_TIME_RPT CAN Message (1039 0x40f)
+#define DATE_TIME_RPT_IDE (0U)
+#define DATE_TIME_RPT_DLC (8U)
+#define DATE_TIME_RPT_CANID (0x40f)
+// signal: @DATE_YEAR_ro
+#define PACMOD5_DATE_YEAR_ro_CovFactor (1)
+#define PACMOD5_DATE_YEAR_ro_toS(x) ( (uint8_t) ((x) - (2000)) )
+#define PACMOD5_DATE_YEAR_ro_fromS(x) ( ((x) + (2000)) )
+// signal: @DATE_MONTH_ro
+#define PACMOD5_DATE_MONTH_ro_CovFactor (1)
+#define PACMOD5_DATE_MONTH_ro_toS(x) ( (uint8_t) ((x) - (1)) )
+#define PACMOD5_DATE_MONTH_ro_fromS(x) ( ((x) + (1)) )
+// signal: @DATE_DAY_ro
+#define PACMOD5_DATE_DAY_ro_CovFactor (1)
+#define PACMOD5_DATE_DAY_ro_toS(x) ( (uint8_t) ((x) - (1)) )
+#define PACMOD5_DATE_DAY_ro_fromS(x) ( ((x) + (1)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t DATE_YEAR_ro;                      //      Bits= 8 Offset= 2000               Unit:'yr'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_YEAR_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t DATE_MONTH_ro;                     //      Bits= 8 Offset= 1                  Unit:'mon'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_MONTH_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t DATE_DAY_ro;                       //      Bits= 8 Offset= 1                  Unit:'dy'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_DAY_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t TIME_HOUR;                         //      Bits= 8 Unit:'hr'
+
+  uint8_t TIME_MINUTE;                       //      Bits= 8 Unit:'min'
+
+  uint8_t TIME_SECOND;                       //      Bits= 8 Unit:'sec'
+
+#else
+
+  uint8_t DATE_YEAR_ro;                      //      Bits= 8 Offset= 2000               Unit:'yr'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_YEAR_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t DATE_MONTH_ro;                     //      Bits= 8 Offset= 1                  Unit:'mon'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_MONTH_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t DATE_DAY_ro;                       //      Bits= 8 Offset= 1                  Unit:'dy'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  uint16_t DATE_DAY_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint8_t TIME_HOUR;                         //      Bits= 8 Unit:'hr'
+
+  uint8_t TIME_MINUTE;                       //      Bits= 8 Unit:'min'
+
+  uint8_t TIME_SECOND;                       //      Bits= 8 Unit:'sec'
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DATE_TIME_RPT_t;
+
+// def @DETECTED_OBJECT_RPT CAN Message (1041 0x411)
+#define DETECTED_OBJECT_RPT_IDE (0U)
+#define DETECTED_OBJECT_RPT_DLC (8U)
+#define DETECTED_OBJECT_RPT_CANID (0x411)
+// signal: @FRONT_OBJECT_DISTANCE_LOW_RES_ro
+#define PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_CovFactor (0.001000)
+#define PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_toS(x) ( (uint32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_FRONT_OBJECT_DISTANCE_LOW_RES_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @FRONT_OBJECT_DISTANCE_HIGH_RES_ro
+#define PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_CovFactor (0.001000)
+#define PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_toS(x) ( (uint32_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_FRONT_OBJECT_DISTANCE_HIGH_RES_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint32_t FRONT_OBJECT_DISTANCE_LOW_RES_ro;       //      Bits=24 Factor= 0.001000        Unit:'m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t FRONT_OBJECT_DISTANCE_LOW_RES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint32_t FRONT_OBJECT_DISTANCE_HIGH_RES_ro;      //      Bits=24 Factor= 0.001000        Unit:'m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t FRONT_OBJECT_DISTANCE_HIGH_RES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint32_t FRONT_OBJECT_DISTANCE_LOW_RES_ro;       //      Bits=24 Factor= 0.001000        Unit:'m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t FRONT_OBJECT_DISTANCE_LOW_RES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  uint32_t FRONT_OBJECT_DISTANCE_HIGH_RES_ro;      //      Bits=24 Factor= 0.001000        Unit:'m'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t FRONT_OBJECT_DISTANCE_HIGH_RES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DETECTED_OBJECT_RPT_t;
+
+// def @VEH_SPECIFIC_RPT_1 CAN Message (1042 0x412)
+#define VEH_SPECIFIC_RPT_1_IDE (0U)
+#define VEH_SPECIFIC_RPT_1_DLC (8U)
+#define VEH_SPECIFIC_RPT_1_CANID (0x412)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t SHIFT_POS_1;                       //      Bits= 8
+
+  uint8_t SHIFT_POS_2;                       //      Bits= 8
+
+#else
+
+  uint8_t SHIFT_POS_1;                       //      Bits= 8
+
+  uint8_t SHIFT_POS_2;                       //      Bits= 8
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} VEH_SPECIFIC_RPT_1_t;
+
+// def @VEH_DYNAMICS_RPT CAN Message (1043 0x413)
+#define VEH_DYNAMICS_RPT_IDE (0U)
+#define VEH_DYNAMICS_RPT_DLC (8U)
+#define VEH_DYNAMICS_RPT_CANID (0x413)
+// signal: @VEH_G_FORCES_ro
+#define PACMOD5_VEH_G_FORCES_ro_CovFactor (0.001000)
+#define PACMOD5_VEH_G_FORCES_ro_toS(x) ( (uint8_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_VEH_G_FORCES_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t VEH_G_FORCES_ro;                   //      Bits= 8 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VEH_G_FORCES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  uint8_t VEH_G_FORCES_ro;                   //      Bits= 8 Factor= 0.001000       
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VEH_G_FORCES_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} VEH_DYNAMICS_RPT_t;
+
+// def @VIN_RPT CAN Message (1044 0x414)
+#define VIN_RPT_IDE (0U)
+#define VIN_RPT_DLC (8U)
+#define VIN_RPT_CANID (0x414)
+#define VIN_RPT_CYC (1000U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint32_t VEH_MFG_CODE;                     //      Bits=24
+
+  uint8_t VEH_MY_CODE;                       //      Bits= 8
+
+  uint32_t VEH_SERIAL;                       //      Bits=24
+
+#else
+
+  uint32_t VEH_MFG_CODE;                     //      Bits=24
+
+  uint8_t VEH_MY_CODE;                       //      Bits= 8
+
+  uint32_t VEH_SERIAL;                       //      Bits=24
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} VIN_RPT_t;
+
+// def @OCCUPANCY_RPT CAN Message (1045 0x415)
+#define OCCUPANCY_RPT_IDE (0U)
+#define OCCUPANCY_RPT_DLC (8U)
+#define OCCUPANCY_RPT_CANID (0x415)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t DRIVER_SEAT_OCCUPIED : 1;               //      Bits= 1
+
+  uint8_t PASS_SEAT_OCCUPIED : 1;                 //      Bits= 1
+
+  uint8_t REAR_SEAT_OCCUPIED : 1;                 //      Bits= 1
+
+  uint8_t DRIVER_SEATBELT_BUCKLED : 1;            //      Bits= 1
+
+  uint8_t PASS_SEATBELT_BUCKLED : 1;              //      Bits= 1
+
+  uint8_t REAR_SEATBELT_BUCKLED : 1;              //      Bits= 1
+
+  uint8_t DRIVER_SEAT_OCCUPIED_IS_VALID : 1;      //      Bits= 1
+
+  uint8_t PASS_SEAT_OCCUPIED_IS_VALID : 1;        //      Bits= 1
+
+  uint8_t REAR_SEAT_OCCUPIED_IS_VALID : 1;        //      Bits= 1
+
+  uint8_t DRIVER_SEATBELT_BUCKLED_IS_VALID : 1;   //      Bits= 1
+
+  uint8_t PASS_SEATBELT_BUCKLED_IS_VALID : 1;     //      Bits= 1
+
+  uint8_t REAR_SEATBELT_BUCKLED_IS_VALID : 1;     //      Bits= 1
+
+#else
+
+  uint8_t DRIVER_SEAT_OCCUPIED;                   //      Bits= 1
+
+  uint8_t PASS_SEAT_OCCUPIED;                     //      Bits= 1
+
+  uint8_t REAR_SEAT_OCCUPIED;                     //      Bits= 1
+
+  uint8_t DRIVER_SEATBELT_BUCKLED;                //      Bits= 1
+
+  uint8_t PASS_SEATBELT_BUCKLED;                  //      Bits= 1
+
+  uint8_t REAR_SEATBELT_BUCKLED;                  //      Bits= 1
+
+  uint8_t DRIVER_SEAT_OCCUPIED_IS_VALID;          //      Bits= 1
+
+  uint8_t PASS_SEAT_OCCUPIED_IS_VALID;            //      Bits= 1
+
+  uint8_t REAR_SEAT_OCCUPIED_IS_VALID;            //      Bits= 1
+
+  uint8_t DRIVER_SEATBELT_BUCKLED_IS_VALID;       //      Bits= 1
+
+  uint8_t PASS_SEATBELT_BUCKLED_IS_VALID;         //      Bits= 1
+
+  uint8_t REAR_SEATBELT_BUCKLED_IS_VALID;         //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} OCCUPANCY_RPT_t;
+
+// def @INTERIOR_LIGHTS_RPT CAN Message (1046 0x416)
+#define INTERIOR_LIGHTS_RPT_IDE (0U)
+#define INTERIOR_LIGHTS_RPT_DLC (8U)
+#define INTERIOR_LIGHTS_RPT_CANID (0x416)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t FRONT_DOME_LIGHTS_ON : 1;            //      Bits= 1
+
+  uint8_t REAR_DOME_LIGHTS_ON : 1;             //      Bits= 1
+
+  uint8_t MOOD_LIGHTS_ON : 1;                  //      Bits= 1
+
+  //  12 : "DIM_LEVEL_MAX"
+  //  11 : "DIM_LEVEL_11"
+  //  10 : "DIM_LEVEL_10"
+  //  9 : "DIM_LEVEL_9"
+  //  8 : "DIM_LEVEL_8"
+  //  7 : "DIM_LEVEL_7"
+  //  6 : "DIM_LEVEL_6"
+  //  5 : "DIM_LEVEL_5"
+  //  4 : "DIM_LEVEL_4"
+  //  3 : "DIM_LEVEL_3"
+  //  2 : "DIM_LEVEL_2"
+  //  1 : "DIM_LEVEL_1"
+  //  0 : "DIM_LEVEL_MIN"
+  uint8_t DIM_LEVEL;                           //      Bits= 8
+
+  uint8_t FRONT_DOME_LIGHTS_ON_IS_VALID : 1;   //      Bits= 1
+
+  uint8_t REAR_DOME_LIGHTS_ON_IS_VALID : 1;    //      Bits= 1
+
+  uint8_t MOOD_LIGHTS_ON_IS_VALID : 1;         //      Bits= 1
+
+  uint8_t DIM_LEVEL_IS_VALID : 1;              //      Bits= 1
+
+#else
+
+  uint8_t FRONT_DOME_LIGHTS_ON;                //      Bits= 1
+
+  uint8_t REAR_DOME_LIGHTS_ON;                 //      Bits= 1
+
+  uint8_t MOOD_LIGHTS_ON;                      //      Bits= 1
+
+  //  12 : "DIM_LEVEL_MAX"
+  //  11 : "DIM_LEVEL_11"
+  //  10 : "DIM_LEVEL_10"
+  //  9 : "DIM_LEVEL_9"
+  //  8 : "DIM_LEVEL_8"
+  //  7 : "DIM_LEVEL_7"
+  //  6 : "DIM_LEVEL_6"
+  //  5 : "DIM_LEVEL_5"
+  //  4 : "DIM_LEVEL_4"
+  //  3 : "DIM_LEVEL_3"
+  //  2 : "DIM_LEVEL_2"
+  //  1 : "DIM_LEVEL_1"
+  //  0 : "DIM_LEVEL_MIN"
+  uint8_t DIM_LEVEL;                           //      Bits= 8
+
+  uint8_t FRONT_DOME_LIGHTS_ON_IS_VALID;       //      Bits= 1
+
+  uint8_t REAR_DOME_LIGHTS_ON_IS_VALID;        //      Bits= 1
+
+  uint8_t MOOD_LIGHTS_ON_IS_VALID;             //      Bits= 1
+
+  uint8_t DIM_LEVEL_IS_VALID;                  //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} INTERIOR_LIGHTS_RPT_t;
+
+// def @DOOR_RPT CAN Message (1047 0x417)
+#define DOOR_RPT_IDE (0U)
+#define DOOR_RPT_DLC (8U)
+#define DOOR_RPT_CANID (0x417)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t DRIVER_DOOR_OPEN : 1;                 //      Bits= 1
+
+  uint8_t PASS_DOOR_OPEN : 1;                   //      Bits= 1
+
+  uint8_t REAR_DRIVER_DOOR_OPEN : 1;            //      Bits= 1
+
+  uint8_t REAR_PASS_DOOR_OPEN : 1;              //      Bits= 1
+
+  uint8_t HOOD_OPEN : 1;                        //      Bits= 1
+
+  uint8_t TRUNK_OPEN : 1;                       //      Bits= 1
+
+  uint8_t FUEL_DOOR_OPEN : 1;                   //      Bits= 1
+
+  uint8_t DRIVER_DOOR_OPEN_IS_VALID : 1;        //      Bits= 1
+
+  uint8_t PASS_DOOR_OPEN_IS_VALID : 1;          //      Bits= 1
+
+  uint8_t REAR_DRIVER_DOOR_OPEN_IS_VALID : 1;   //      Bits= 1
+
+  uint8_t REAR_PASS_DOOR_OPEN_IS_VALID : 1;     //      Bits= 1
+
+  uint8_t HOOD_OPEN_IS_VALID : 1;               //      Bits= 1
+
+  uint8_t TRUNK_OPEN_IS_VALID : 1;              //      Bits= 1
+
+  uint8_t FUEL_DOOR_OPEN_IS_VALID : 1;          //      Bits= 1
+
+#else
+
+  uint8_t DRIVER_DOOR_OPEN;                     //      Bits= 1
+
+  uint8_t PASS_DOOR_OPEN;                       //      Bits= 1
+
+  uint8_t REAR_DRIVER_DOOR_OPEN;                //      Bits= 1
+
+  uint8_t REAR_PASS_DOOR_OPEN;                  //      Bits= 1
+
+  uint8_t HOOD_OPEN;                            //      Bits= 1
+
+  uint8_t TRUNK_OPEN;                           //      Bits= 1
+
+  uint8_t FUEL_DOOR_OPEN;                       //      Bits= 1
+
+  uint8_t DRIVER_DOOR_OPEN_IS_VALID;            //      Bits= 1
+
+  uint8_t PASS_DOOR_OPEN_IS_VALID;              //      Bits= 1
+
+  uint8_t REAR_DRIVER_DOOR_OPEN_IS_VALID;       //      Bits= 1
+
+  uint8_t REAR_PASS_DOOR_OPEN_IS_VALID;         //      Bits= 1
+
+  uint8_t HOOD_OPEN_IS_VALID;                   //      Bits= 1
+
+  uint8_t TRUNK_OPEN_IS_VALID;                  //      Bits= 1
+
+  uint8_t FUEL_DOOR_OPEN_IS_VALID;              //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} DOOR_RPT_t;
+
+// def @REAR_LIGHTS_RPT CAN Message (1048 0x418)
+#define REAR_LIGHTS_RPT_IDE (0U)
+#define REAR_LIGHTS_RPT_DLC (8U)
+#define REAR_LIGHTS_RPT_CANID (0x418)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  uint8_t BRAKE_LIGHTS_ON : 1;               //      Bits= 1
+
+  uint8_t REVERSE_LIGHTS_ON : 1;             //      Bits= 1
+
+  uint8_t BRAKE_LIGHTS_ON_IS_VALID : 1;      //      Bits= 1
+
+  uint8_t REVERSE_LIGHTS_ON_IS_VALID : 1;    //      Bits= 1
+
+#else
+
+  uint8_t BRAKE_LIGHTS_ON;                   //      Bits= 1
+
+  uint8_t REVERSE_LIGHTS_ON;                 //      Bits= 1
+
+  uint8_t BRAKE_LIGHTS_ON_IS_VALID;          //      Bits= 1
+
+  uint8_t REVERSE_LIGHTS_ON_IS_VALID;        //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} REAR_LIGHTS_RPT_t;
+
+// def @LINEAR_ACCEL_RPT CAN Message (1049 0x419)
+#define LINEAR_ACCEL_RPT_IDE (0U)
+#define LINEAR_ACCEL_RPT_DLC (8U)
+#define LINEAR_ACCEL_RPT_CANID (0x419)
+// signal: @LATERAL_ACCEL_ro
+#define PACMOD5_LATERAL_ACCEL_ro_CovFactor (0.010000)
+#define PACMOD5_LATERAL_ACCEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_LATERAL_ACCEL_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+// signal: @LONGITUDNAL_ACCEL_ro
+#define PACMOD5_LONGITUDNAL_ACCEL_ro_CovFactor (0.010000)
+#define PACMOD5_LONGITUDNAL_ACCEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_LONGITUDNAL_ACCEL_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+// signal: @VERTICAL_ACCEL_ro
+#define PACMOD5_VERTICAL_ACCEL_ro_CovFactor (0.010000)
+#define PACMOD5_VERTICAL_ACCEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.010000)) )
+#define PACMOD5_VERTICAL_ACCEL_ro_fromS(x) ( (((x) * (0.010000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t LATERAL_NEW_DATA_RX : 1;           //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t LONGITUDNAL_NEW_DATA_RX : 1;       //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t VERTICAL_NEW_DATA_RX : 1;          //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t LATERAL_VALID : 1;                 //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t LONGITUDNAL_VALID : 1;             //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t VERTICAL_VALID : 1;                //      Bits= 1
+
+  int16_t LATERAL_ACCEL_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LATERAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t LONGITUDNAL_ACCEL_ro;              //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LONGITUDNAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t VERTICAL_ACCEL_ro;                 //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VERTICAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t LATERAL_NEW_DATA_RX;               //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t LONGITUDNAL_NEW_DATA_RX;           //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t VERTICAL_NEW_DATA_RX;              //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t LATERAL_VALID;                     //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t LONGITUDNAL_VALID;                 //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t VERTICAL_VALID;                    //      Bits= 1
+
+  int16_t LATERAL_ACCEL_ro;                  //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LATERAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t LONGITUDNAL_ACCEL_ro;              //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t LONGITUDNAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t VERTICAL_ACCEL_ro;                 //  [-] Bits=16 Factor= 0.010000        Unit:'m/s^2'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t VERTICAL_ACCEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} LINEAR_ACCEL_RPT_t;
+
+// def @ANG_VEL_RPT CAN Message (1050 0x41a)
+#define ANG_VEL_RPT_IDE (0U)
+#define ANG_VEL_RPT_DLC (8U)
+#define ANG_VEL_RPT_CANID (0x41a)
+// signal: @PITCH_VEL_ro
+#define PACMOD5_PITCH_VEL_ro_CovFactor (0.001000)
+#define PACMOD5_PITCH_VEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_PITCH_VEL_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @ROLL_VEL_ro
+#define PACMOD5_ROLL_VEL_ro_CovFactor (0.001000)
+#define PACMOD5_ROLL_VEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_ROLL_VEL_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+// signal: @YAW_VEL_ro
+#define PACMOD5_YAW_VEL_ro_CovFactor (0.001000)
+#define PACMOD5_YAW_VEL_ro_toS(x) ( (int16_t) (((x) - (0.000000)) / (0.001000)) )
+#define PACMOD5_YAW_VEL_ro_fromS(x) ( (((x) * (0.001000)) + (0.000000)) )
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t PITCH_NEW_DATA_RX : 1;             //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t ROLL_NEW_DATA_RX : 1;              //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t YAW_NEW_DATA_RX : 1;               //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t PITCH_VALID : 1;                   //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t ROLL_VALID : 1;                    //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t YAW_VALID : 1;                     //      Bits= 1
+
+  int16_t PITCH_VEL_ro;                      //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t PITCH_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t ROLL_VEL_ro;                       //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROLL_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t YAW_VEL_ro;                        //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t YAW_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#else
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t PITCH_NEW_DATA_RX;                 //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t ROLL_NEW_DATA_RX;                  //      Bits= 1
+
+  //  0 : "NEW_DATA_NOT_RX"
+  //  1 : "NEW_DATA_RX"
+  uint8_t YAW_NEW_DATA_RX;                   //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t PITCH_VALID;                       //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t ROLL_VALID;                        //      Bits= 1
+
+  //  0 : "NOT_VALID"
+  //  1 : "VALID"
+  uint8_t YAW_VALID;                         //      Bits= 1
+
+  int16_t PITCH_VEL_ro;                      //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t PITCH_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t ROLL_VEL_ro;                       //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t ROLL_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+  int16_t YAW_VEL_ro;                        //  [-] Bits=16 Factor= 0.001000        Unit:'rad/s'
+
+#ifdef PACMOD5_USE_SIGFLOAT
+  sigfloat_t YAW_VEL_phys;
+#endif // PACMOD5_USE_SIGFLOAT
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ANG_VEL_RPT_t;
+
+// def @NOTIFICATION_CMD CAN Message (1051 0x41b)
+#define NOTIFICATION_CMD_IDE (0U)
+#define NOTIFICATION_CMD_DLC (8U)
+#define NOTIFICATION_CMD_CANID (0x41b)
+#define NOTIFICATION_CMD_CYC (250U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "NOT_MUTED"
+  //  1 : "MUTED"
+  uint8_t BUZZER_MUTE : 1;                   //      Bits= 1
+
+  //  0 : "NO_ACTION"
+  //  1 : "WHITE"
+  uint8_t UNDERDASH_LIGHTS_WHITE : 1;        //      Bits= 1
+
+#else
+
+  //  0 : "NOT_MUTED"
+  //  1 : "MUTED"
+  uint8_t BUZZER_MUTE;                       //      Bits= 1
+
+  //  0 : "NO_ACTION"
+  //  1 : "WHITE"
+  uint8_t UNDERDASH_LIGHTS_WHITE;            //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} NOTIFICATION_CMD_t;
+
+// def @ESTOP_RPT CAN Message (1052 0x41c)
+#define ESTOP_RPT_IDE (0U)
+#define ESTOP_RPT_DLC (8U)
+#define ESTOP_RPT_CANID (0x41c)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "RELEASED"
+  //  1 : "PRESSED"
+  uint8_t ESTOP : 1;                         //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t ESTOP_FAULT : 1;                   //      Bits= 1
+
+#else
+
+  //  0 : "RELEASED"
+  //  1 : "PRESSED"
+  uint8_t ESTOP;                             //      Bits= 1
+
+  //  0 : "NO_FAULT"
+  //  1 : "FAULT"
+  uint8_t ESTOP_FAULT;                       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} ESTOP_RPT_t;
+
+// def @WATCHDOG_RPT CAN Message (1536 0x600)
+#define WATCHDOG_RPT_IDE (0U)
+#define WATCHDOG_RPT_DLC (8U)
+#define WATCHDOG_RPT_CANID (0x600)
+#define WATCHDOG_RPT_CYC (100U)
+
+typedef struct
+{
+#ifdef PACMOD5_USE_BITS_SIGNAL
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_ENABLE_FLAG : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_OVERRIDE_ACTIVE : 1;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_COMMAND_TIMEOUT_ERROR : 1;         //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_PACMOD_SUBSYSTEM_TIMEOUT : 1;      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_VEHICLE_CAN_TIMEOUT : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_PACMOD_SYSTEM_FAULT_ACTIVE : 1;    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_CONFIG_FAULT_ACTIVE : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_TIMEOUT : 1;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_ENABLED : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_OVERRIDE_ACTIVE : 1;                //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_COMMAND_OUTPUT_FAULT : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_INPUT_OUTPUT_FAULT : 1;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_OUTPUT_REPORTED_FAULT : 1;          //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_PACMOD_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_VEHICLE_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_TIMEOUT : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_ENABLED : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_OVERRIDE_ACTIVE : 1;                //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_COMMAND_OUTPUT_FAULT : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_INPUT_OUTPUT_FAULT : 1;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_OUTPUT_REPORTED_FAULT : 1;          //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_PACMOD_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_VEHICLE_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_TIMEOUT : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_ENABLED : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_OVERRIDE_ACTIVE : 1;                //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_COMMAND_OUTPUT_FAULT : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_INPUT_OUTPUT_FAULT : 1;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_OUTPUT_REPORTED_FAULT : 1;          //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_PACMOD_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_VEHICLE_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_TIMEOUT : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_ENABLED : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_OVERRIDE_ACTIVE : 1;                //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_COMMAND_OUTPUT_FAULT : 1;           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_INPUT_OUTPUT_FAULT : 1;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_OUTPUT_REPORTED_FAULT : 1;          //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_PACMOD_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_VEHICLE_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_TIMEOUT : 1;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_CAN_TIMEOUT : 1;                     //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_COUNTER_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_CAN_TIMEOUT : 1;                     //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_COUNTER_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_CONFIG_FAULT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_CAN_TIMEOUT : 1;                     //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_COUNTER_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_RPT_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_CONFIG_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_CAN_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_COUNTER_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_RPT_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_CONFIG_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_CAN_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_COUNTER_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_RPT_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_CONFIG_FAULT : 1;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_CAN_TIMEOUT : 1;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_COUNTER_FAULT : 1;                  //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD_SYSTEM_PRESENT_FAULT : 1;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI_SYSTEM_PRESENT_FAULT : 1;            //      Bits= 1
+
+  uint8_t GLOBAL_INTERNAL_POWER_SUPPLY_FAULT : 1;   //      Bits= 1
+
+#else
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_ENABLE_FLAG;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_OVERRIDE_ACTIVE;                   //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_COMMAND_TIMEOUT_ERROR;             //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_PACMOD_SUBSYSTEM_TIMEOUT;          //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_VEHICLE_CAN_TIMEOUT;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_PACMOD_SYSTEM_FAULT_ACTIVE;        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_CONFIG_FAULT_ACTIVE;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t GLOBAL_TIMEOUT;                           //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_ENABLED;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_OVERRIDE_ACTIVE;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_COMMAND_OUTPUT_FAULT;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_INPUT_OUTPUT_FAULT;                 //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_OUTPUT_REPORTED_FAULT;              //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_PACMOD_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_VEHICLE_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t ACCEL_TIMEOUT;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_ENABLED;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_OVERRIDE_ACTIVE;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_COMMAND_OUTPUT_FAULT;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_INPUT_OUTPUT_FAULT;                 //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_OUTPUT_REPORTED_FAULT;              //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_PACMOD_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_VEHICLE_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t BRAKE_TIMEOUT;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_ENABLED;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_OVERRIDE_ACTIVE;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_COMMAND_OUTPUT_FAULT;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_INPUT_OUTPUT_FAULT;                 //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_OUTPUT_REPORTED_FAULT;              //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_PACMOD_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_VEHICLE_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t SHIFT_TIMEOUT;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_ENABLED;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_OVERRIDE_ACTIVE;                    //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_COMMAND_OUTPUT_FAULT;               //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_INPUT_OUTPUT_FAULT;                 //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_OUTPUT_REPORTED_FAULT;              //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_PACMOD_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_VEHICLE_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t STEER_TIMEOUT;                            //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_CAN_TIMEOUT;                         //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD1_COUNTER_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_CAN_TIMEOUT;                         //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD2_COUNTER_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_CONFIG_FAULT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_CAN_TIMEOUT;                         //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD3_COUNTER_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_RPT_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_CONFIG_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_CAN_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI1_COUNTER_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_RPT_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_CONFIG_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_CAN_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI2_COUNTER_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_RPT_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_CONFIG_FAULT;                       //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_CAN_TIMEOUT;                        //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI3_COUNTER_FAULT;                      //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MOD_SYSTEM_PRESENT_FAULT;                 //      Bits= 1
+
+  //  0 : "FALSE"
+  //  1 : "TRUE"
+  uint8_t MINI_SYSTEM_PRESENT_FAULT;                //      Bits= 1
+
+  uint8_t GLOBAL_INTERNAL_POWER_SUPPLY_FAULT;       //      Bits= 1
+
+#endif // PACMOD5_USE_BITS_SIGNAL
+
+#ifdef PACMOD5_USE_DIAG_MONITORS
+
+  FrameMonitor_t mon1;
+
+#endif // PACMOD5_USE_DIAG_MONITORS
+
+} WATCHDOG_RPT_t;
+
+// Function signatures
+
+uint32_t Unpack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_GLOBAL_RPT_pacmod5(GLOBAL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_COMPONENT_RPT_00_pacmod5(COMPONENT_RPT_00_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_COMPONENT_RPT_01_pacmod5(COMPONENT_RPT_01_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_COMPONENT_RPT_02_pacmod5(COMPONENT_RPT_02_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_COMPONENT_RPT_03_pacmod5(COMPONENT_RPT_03_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_GLOBAL_CMD_pacmod5(GLOBAL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ACCEL_CMD_pacmod5(ACCEL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_CMD_pacmod5(BRAKE_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_CMD_pacmod5(CRUISE_CONTROL_BUTTONS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DASH_CONTROLS_LEFT_CMD_pacmod5(DASH_CONTROLS_LEFT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DASH_CONTROLS_RIGHT_CMD_pacmod5(DASH_CONTROLS_RIGHT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HAZARD_LIGHTS_CMD_pacmod5(HAZARD_LIGHTS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HEADLIGHT_CMD_pacmod5(HEADLIGHT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HORN_CMD_pacmod5(HORN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HORN_CMD_pacmod5(HORN_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HORN_CMD_pacmod5(HORN_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_MEDIA_CONTROLS_CMD_pacmod5(MEDIA_CONTROLS_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_PARKING_BRAKE_CMD_pacmod5(PARKING_BRAKE_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SHIFT_CMD_pacmod5(SHIFT_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_CMD_pacmod5(STEERING_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_CMD_pacmod5(TURN_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_TURN_CMD_pacmod5(TURN_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_TURN_CMD_pacmod5(TURN_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_WIPER_CMD_pacmod5(WIPER_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SPRAYER_CMD_pacmod5(SPRAYER_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_DECCEL_CMD_pacmod5(BRAKE_DECCEL_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ACCEL_RPT_pacmod5(ACCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ACCEL_CMD_LIMIT_RPT_pacmod5(ACCEL_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_RPT_pacmod5(BRAKE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_CMD_LIMIT_RPT_pacmod5(BRAKE_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_CRUISE_CONTROL_BUTTONS_RPT_pacmod5(CRUISE_CONTROL_BUTTONS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DASH_CONTROLS_LEFT_RPT_pacmod5(DASH_CONTROLS_LEFT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DASH_CONTROLS_RIGHT_RPT_pacmod5(DASH_CONTROLS_RIGHT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HAZARD_LIGHTS_RPT_pacmod5(HAZARD_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HEADLIGHT_RPT_pacmod5(HEADLIGHT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HORN_RPT_pacmod5(HORN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HORN_RPT_pacmod5(HORN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HORN_RPT_pacmod5(HORN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_MEDIA_CONTROLS_RPT_pacmod5(MEDIA_CONTROLS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_PARKING_BRAKE_RPT_pacmod5(PARKING_BRAKE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SHIFT_RPT_pacmod5(SHIFT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_RPT_pacmod5(STEERING_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_CMD_LIMIT_RPT_pacmod5(STEERING_CMD_LIMIT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_RPT_pacmod5(TURN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_TURN_RPT_pacmod5(TURN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_TURN_RPT_pacmod5(TURN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_WIPER_RPT_pacmod5(WIPER_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SPRAYER_RPT_pacmod5(SPRAYER_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_DECCEL_RPT_pacmod5(BRAKE_DECCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ACCEL_AUX_RPT_pacmod5(ACCEL_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_AUX_RPT_pacmod5(BRAKE_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_HEADLIGHT_AUX_RPT_pacmod5(HEADLIGHT_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SHIFT_AUX_RPT_pacmod5(SHIFT_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_AUX_RPT_pacmod5(STEERING_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_TURN_AUX_RPT_pacmod5(TURN_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_WIPER_AUX_RPT_pacmod5(WIPER_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_DECCEL_AUX_RPT_pacmod5(BRAKE_DECCEL_AUX_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_VEHICLE_SPEED_RPT_pacmod5(VEHICLE_SPEED_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_MOTOR_RPT_1_pacmod5(BRAKE_MOTOR_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_MOTOR_RPT_2_pacmod5(BRAKE_MOTOR_RPT_2_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_BRAKE_MOTOR_RPT_3_pacmod5(BRAKE_MOTOR_RPT_3_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_MOTOR_RPT_1_pacmod5(STEERING_MOTOR_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_MOTOR_RPT_2_pacmod5(STEERING_MOTOR_RPT_2_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_STEERING_MOTOR_RPT_3_pacmod5(STEERING_MOTOR_RPT_3_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_WHEEL_SPEED_RPT_pacmod5(WHEEL_SPEED_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SOFTWARE_VERSION_RPT_00_pacmod5(SOFTWARE_VERSION_RPT_00_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SOFTWARE_VERSION_RPT_01_pacmod5(SOFTWARE_VERSION_RPT_01_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SOFTWARE_VERSION_RPT_02_pacmod5(SOFTWARE_VERSION_RPT_02_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_SOFTWARE_VERSION_RPT_03_pacmod5(SOFTWARE_VERSION_RPT_03_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_YAW_RATE_RPT_pacmod5(YAW_RATE_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_LAT_LON_HEADING_RPT_pacmod5(LAT_LON_HEADING_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DATE_TIME_RPT_pacmod5(DATE_TIME_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DETECTED_OBJECT_RPT_pacmod5(DETECTED_OBJECT_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_VEH_SPECIFIC_RPT_1_pacmod5(VEH_SPECIFIC_RPT_1_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_VEH_DYNAMICS_RPT_pacmod5(VEH_DYNAMICS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_VIN_RPT_pacmod5(VIN_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_VIN_RPT_pacmod5(VIN_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_VIN_RPT_pacmod5(VIN_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_OCCUPANCY_RPT_pacmod5(OCCUPANCY_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_INTERIOR_LIGHTS_RPT_pacmod5(INTERIOR_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_DOOR_RPT_pacmod5(DOOR_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_REAR_LIGHTS_RPT_pacmod5(REAR_LIGHTS_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_LINEAR_ACCEL_RPT_pacmod5(LINEAR_ACCEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ANG_VEL_RPT_pacmod5(ANG_VEL_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_NOTIFICATION_CMD_pacmod5(NOTIFICATION_CMD_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_ESTOP_RPT_pacmod5(ESTOP_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+uint32_t Unpack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, const uint8_t* _d, uint8_t dlc_);
+#ifdef PACMOD5_USE_CANSTRUCT
+uint32_t Pack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, __CoderDbcCanFrame_t__* cframe);
+#else
+uint32_t Pack_WATCHDOG_RPT_pacmod5(WATCHDOG_RPT_t* _m, uint8_t* _d, uint8_t* _len, uint8_t* _ide);
+#endif // PACMOD5_USE_CANSTRUCT
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/pacmod3_dbc3_ros_api.cpp
+++ b/src/pacmod3_dbc3_ros_api.cpp
@@ -189,6 +189,15 @@ std::shared_ptr<void> Dbc3Api::ParseDoorRpt(const cn_msgs::Frame& can_msg)
   return new_msg;
 }
 
+std::shared_ptr<void> Dbc3Api::ParseEStopRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::EStopRpt>();
+
+  PrintParseError("EStopRpt");
+
+  return new_msg;
+}
+
 std::shared_ptr<void> Dbc3Api::ParseEngineRpt(const cn_msgs::Frame& can_msg)
 {
   auto new_msg = std::make_shared<pm_msgs::EngineRpt>();

--- a/src/pacmod3_dbc5_ros_api.cpp
+++ b/src/pacmod3_dbc5_ros_api.cpp
@@ -78,6 +78,19 @@ std::shared_ptr<void> Dbc5Api::ParseComponentRpt(const cn_msgs::Frame& can_msg)
   return new_msg;
 }
 
+std::shared_ptr<void> Dbc5Api::ParseEStopRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::EStopRpt>();
+
+  ESTOP_RPT_t parsed_rpt;
+  Unpack_ESTOP_RPT_pacmod5(&parsed_rpt, static_cast<const uint8_t*>(&can_msg.data[0]), static_cast<uint8_t>(can_msg.dlc));
+
+  new_msg->estop_status = parsed_rpt.ESTOP;
+  new_msg->estop_fault = parsed_rpt.ESTOP_FAULT;
+
+  return new_msg;
+}
+
 std::shared_ptr<void> Dbc5Api::ParseShiftAuxRpt(const cn_msgs::Frame& can_msg)
 {
   auto new_msg = std::make_shared<pm_msgs::ShiftAuxRpt>();
@@ -89,10 +102,10 @@ std::shared_ptr<void> Dbc5Api::ParseShiftAuxRpt(const cn_msgs::Frame& can_msg)
   new_msg->stay_in_neutral_mode = parsed_rpt.STAY_IN_NEUTRAL_MODE;
   new_msg->brake_interlock_active = parsed_rpt.BRAKE_INTERLOCK_ACTIVE;
   new_msg->speed_interlock_active = parsed_rpt.SPEED_INTERLOCK_ACTIVE;
-  new_msg->between_gears_avail = parsed_rpt.BETWEEN_GEARS_IS_VALID;
-  new_msg->stay_in_neutral_mode_avail = parsed_rpt.STAY_IN_NEUTRAL_MODE_IS_VALID;
-  new_msg->brake_interlock_active_avail = parsed_rpt.BRAKE_INTERLOCK_ACTIVE_IS_VALID;
-  new_msg->speed_interlock_active_avail = parsed_rpt.SPEED_INTERLOCK_ACTIVE_IS_VALID;
+  new_msg->between_gears_avail = parsed_rpt.BETWEEN_GEARS_AVAIL;
+  new_msg->stay_in_neutral_mode_avail = parsed_rpt.STAY_IN_NEUTRAL_MODE_AVAIL;
+  new_msg->brake_interlock_active_avail = parsed_rpt.BRAKE_INTERLOCK_ACTIVE_AVAIL;
+  new_msg->speed_interlock_active_avail = parsed_rpt.SPEED_INTERLOCK_ACTIVE_AVAIL;
   new_msg->write_to_config = parsed_rpt.WRITE_TO_CONFIG;
 
   // Following fields not present in dbc5

--- a/src/pacmod3_dbc5_ros_api.cpp
+++ b/src/pacmod3_dbc5_ros_api.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2022 AutonomouStuff, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "pacmod3_dbc5_ros_api.h"
+#include "autogen/pacmod5.h"
+
+#include <vector>
+#include <string>
+#include <memory>
+
+
+namespace pacmod3_common
+{
+
+std::shared_ptr<void> Dbc5Api::ParseComponentRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::ComponentRpt>();
+
+  COMPONENT_RPT_00_t parsed_rpt;
+  Unpack_COMPONENT_RPT_00_pacmod5(&parsed_rpt, static_cast<const uint8_t*>(&can_msg.data[0]), static_cast<uint8_t>(can_msg.dlc));
+
+  new_msg->component_type = parsed_rpt.COMPONENT_TYPE;
+  new_msg->accel = parsed_rpt.ACCEL;
+  new_msg->brake = parsed_rpt.BRAKE;
+  new_msg->cruise_control_buttons = parsed_rpt.CRUISE_CONTROL_BUTTONS;
+  new_msg->dash_controls_left = parsed_rpt.DASH_CONTROLS_LEFT;
+  new_msg->dash_controls_right = parsed_rpt.DASH_CONTROLS_RIGHT;
+  new_msg->hazard_lights = parsed_rpt.HAZARD_LIGHTS;
+  new_msg->headlight = parsed_rpt.HEADLIGHT;
+  new_msg->horn = parsed_rpt.HORN;
+  new_msg->media_controls = parsed_rpt.MEDIA_CONTROLS;
+  new_msg->parking_brake = parsed_rpt.PARKING_BRAKE;
+  new_msg->shift = parsed_rpt.SHIFT;
+  new_msg->sprayer = parsed_rpt.SPRAY;
+  new_msg->steering = parsed_rpt.STEERING;
+  new_msg->turn = parsed_rpt.TURN;
+  new_msg->wiper = parsed_rpt.WIPER;
+  new_msg->watchdog = parsed_rpt.WATCHDOG;
+  new_msg->brake_deccel = parsed_rpt.BRAKE_DECCEL;
+
+  // Following fields not present in dbc5
+  new_msg->cabin_climate = 0;
+  new_msg->cabin_fan_speed = 0;
+  new_msg->cabin_temp = 0;
+  new_msg->engine_brake = 0;
+  new_msg->marker_lamp = 0;
+  new_msg->rear_pass_door = 0;
+
+  new_msg->counter = parsed_rpt.COUNTER;
+  new_msg->complement = parsed_rpt.COMPLEMENT;
+  new_msg->config_fault = parsed_rpt.CONFIG_FAULT;
+  new_msg->can_timeout_fault = parsed_rpt.CAN_TIMEOUT_FAULT;
+  new_msg->internal_supply_voltage_fault = parsed_rpt.INTERNAL_SUPPLY_VOLTAGE_FAULT;
+
+  // Following fields not present in dbc5
+  new_msg->supervisory_timeout = 0;
+  new_msg->supervisory_sanity_fault = 0;
+  new_msg->watchdog_sanity_fault = 0;
+  new_msg->watchdog_system_present_fault = 0;
+
+  return new_msg;
+}
+
+std::shared_ptr<void> Dbc5Api::ParseShiftAuxRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::ShiftAuxRpt>();
+
+  SHIFT_AUX_RPT_t parsed_rpt;
+  Unpack_SHIFT_AUX_RPT_pacmod5(&parsed_rpt, static_cast<const uint8_t*>(&can_msg.data[0]), static_cast<uint8_t>(can_msg.dlc));
+
+  new_msg->between_gears = parsed_rpt.BETWEEN_GEARS;
+  new_msg->stay_in_neutral_mode = parsed_rpt.STAY_IN_NEUTRAL_MODE;
+  new_msg->brake_interlock_active = parsed_rpt.BRAKE_INTERLOCK_ACTIVE;
+  new_msg->speed_interlock_active = parsed_rpt.SPEED_INTERLOCK_ACTIVE;
+  new_msg->between_gears_avail = parsed_rpt.BETWEEN_GEARS_IS_VALID;
+  new_msg->stay_in_neutral_mode_avail = parsed_rpt.STAY_IN_NEUTRAL_MODE_IS_VALID;
+  new_msg->brake_interlock_active_avail = parsed_rpt.BRAKE_INTERLOCK_ACTIVE_IS_VALID;
+  new_msg->speed_interlock_active_avail = parsed_rpt.SPEED_INTERLOCK_ACTIVE_IS_VALID;
+  new_msg->write_to_config = parsed_rpt.WRITE_TO_CONFIG;
+
+  // Following fields not present in dbc5
+  new_msg->gear_number = 0;
+  new_msg->gear_number_avail = false;
+  new_msg->write_to_config_is_valid = false;
+
+  return new_msg;
+}
+
+std::shared_ptr<void> Dbc5Api::ParseWheelSpeedRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::WheelSpeedRpt>();
+
+  WHEEL_SPEED_RPT_t parsed_rpt;
+  Unpack_WHEEL_SPEED_RPT_pacmod5(&parsed_rpt, static_cast<const uint8_t*>(&can_msg.data[0]), static_cast<uint8_t>(can_msg.dlc));
+
+  new_msg->front_left_wheel_speed = parsed_rpt.WHEEL_SPD_FRONT_LEFT_phys;
+  new_msg->front_right_wheel_speed = parsed_rpt.WHEEL_SPD_FRONT_RIGHT_phys;
+  new_msg->rear_left_wheel_speed = parsed_rpt.WHEEL_SPD_REAR_LEFT_phys;
+  new_msg->rear_right_wheel_speed = parsed_rpt.WHEEL_SPD_REAR_RIGHT_phys;
+
+  return new_msg;
+}
+
+}  // namespace pacmod3_common


### PR DESCRIPTION
Resolves #2 by adding DBC5 support. This is the first version to introduce the `EStopRpt` msg which is needed for the CRV SSC.

I also updated the script that autogenerates the parsing code, to remove any need to manually edit the autogenerated code.

Note that anything under the `autogen/` folder does not need to be reviewed.