### PR TITLE
fix steering in honda

### DIFF
--- a/include/pacmod3_dbc4_ros_api.h
+++ b/include/pacmod3_dbc4_ros_api.h
@@ -51,6 +51,7 @@ public:
   cn_msgs::Frame EncodeCmd(const pm_msgs::SystemCmdBool& msg) override;
   cn_msgs::Frame EncodeCmd(const pm_msgs::SystemCmdFloat& msg) override;
   cn_msgs::Frame EncodeCmd(const pm_msgs::SystemCmdInt& msg) override;
+  cn_msgs::Frame EncodeCmd(const pm_msgs::SteeringCmd& msg) override;
 };
 }  // namespace pacmod3_common
 

--- a/src/pacmod3_dbc3_ros_api.cpp
+++ b/src/pacmod3_dbc3_ros_api.cpp
@@ -646,8 +646,9 @@ cn_msgs::Frame Dbc3Api::EncodeCmd(const pm_msgs::SteeringCmd& msg)
   unpacked_cmd.ENABLE = msg.enable;
   unpacked_cmd.IGNORE_OVERRIDES = msg.ignore_overrides;
   unpacked_cmd.CLEAR_OVERRIDE = msg.clear_override;
+  unpacked_cmd.CLEAR_FAULTS = 0; // Signal present in dbc3 but not in pm_msgs::SteeringCmd
   unpacked_cmd.POSITION_phys = msg.command;
-  unpacked_cmd.ROTATION_RATE_phys = msg.command;
+  unpacked_cmd.ROTATION_RATE_phys = msg.rotation_rate;
 
   uint8_t unused_ide;
   Pack_STEERING_CMD_pacmod3(&unpacked_cmd, static_cast<uint8_t*>(&packed_frame.data[0]), static_cast<uint8_t*>(&packed_frame.dlc), &unused_ide);
@@ -663,6 +664,7 @@ cn_msgs::Frame Dbc3Api::EncodeCmd(const pm_msgs::SystemCmdBool& msg)
   unpacked_cmd.ENABLE = msg.enable;
   unpacked_cmd.IGNORE_OVERRIDES = msg.ignore_overrides;
   unpacked_cmd.CLEAR_OVERRIDE = msg.clear_override;
+  unpacked_cmd.CLEAR_FAULTS = 0; // Signal present in dbc3 but not in pm_msgs::SystemCmdBool
   unpacked_cmd.HORN_CMD = msg.command;
 
   uint8_t unused_ide;
@@ -679,6 +681,7 @@ cn_msgs::Frame Dbc3Api::EncodeCmd(const pm_msgs::SystemCmdFloat& msg)
   unpacked_cmd.ENABLE = msg.enable;
   unpacked_cmd.IGNORE_OVERRIDES = msg.ignore_overrides;
   unpacked_cmd.CLEAR_OVERRIDE = msg.clear_override;
+  unpacked_cmd.CLEAR_FAULTS = 0; // Signal present in dbc3 but not in pm_msgs::SystemCmdFloat
   unpacked_cmd.ACCEL_CMD_phys = msg.command;
 
   uint8_t unused_ide;
@@ -695,6 +698,7 @@ cn_msgs::Frame Dbc3Api::EncodeCmd(const pm_msgs::SystemCmdInt& msg)
   unpacked_cmd.ENABLE = msg.enable;
   unpacked_cmd.IGNORE_OVERRIDES = msg.ignore_overrides;
   unpacked_cmd.CLEAR_OVERRIDE = msg.clear_override;
+  unpacked_cmd.CLEAR_FAULTS = 0; // Signal present in dbc3 but not in pm_msgs::SystemCmdInt
   unpacked_cmd.SHIFT_CMD = msg.command;
 
   uint8_t unused_ide;

--- a/src/pacmod3_dbc4_ros_api.cpp
+++ b/src/pacmod3_dbc4_ros_api.cpp
@@ -265,4 +265,21 @@ cn_msgs::Frame Dbc4Api::EncodeCmd(const pm_msgs::SystemCmdFloat& msg)
   return packed_frame;
 }
 
+cn_msgs::Frame Dbc4Api::EncodeCmd(const pm_msgs::SteeringCmd& msg)
+{
+  cn_msgs::Frame packed_frame;
+
+  STEERING_CMD_t unpacked_cmd;
+  unpacked_cmd.ENABLE = msg.enable;
+  unpacked_cmd.IGNORE_OVERRIDES = msg.ignore_overrides;
+  unpacked_cmd.CLEAR_OVERRIDE = msg.clear_override;
+  unpacked_cmd.POSITION_phys = msg.command;
+  unpacked_cmd.ROTATION_RATE_phys = msg.rotation_rate;
+
+  uint8_t unused_ide;
+  Pack_STEERING_CMD_pacmod4(&unpacked_cmd, static_cast<uint8_t*>(&packed_frame.data[0]), static_cast<uint8_t*>(&packed_frame.dlc), &unused_ide);
+
+  return packed_frame;
+}
+
 }  // namespace pacmod3_common


### PR DESCRIPTION
override SteeringCmd in dbc4 to add rotation_rate and get rid of CLEAR_FAULTS