### PR TITLE
fix steering rpt

### DIFF
--- a/include/pacmod3_dbc3_ros_api.h
+++ b/include/pacmod3_dbc3_ros_api.h
@@ -62,6 +62,7 @@ public:
   std::shared_ptr<void> ParseSystemRptBool(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseSystemRptFloat(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseSystemRptInt(const cn_msgs::Frame& can_msg) override;
+  std::shared_ptr<void> ParseSteeringRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseTurnAuxRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseVehicleDynamicsRpt(const cn_msgs::Frame& can_msg) override;
   std::shared_ptr<void> ParseVehicleSpeedRpt(const cn_msgs::Frame& can_msg) override;

--- a/include/pacmod3_dbc_ros_api.h
+++ b/include/pacmod3_dbc_ros_api.h
@@ -170,6 +170,7 @@ public:
   virtual std::shared_ptr<void> ParseSystemRptBool(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseSystemRptFloat(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseSystemRptInt(const cn_msgs::Frame& can_msg) = 0;
+  virtual std::shared_ptr<void> ParseSteeringRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseTurnAuxRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseVehicleDynamicsRpt(const cn_msgs::Frame& can_msg) = 0;
   virtual std::shared_ptr<void> ParseVehicleSpeedRpt(const cn_msgs::Frame& can_msg) = 0;

--- a/src/pacmod3_dbc3_ros_api.cpp
+++ b/src/pacmod3_dbc3_ros_api.cpp
@@ -487,6 +487,28 @@ std::shared_ptr<void> Dbc3Api::ParseSystemRptFloat(const cn_msgs::Frame& can_msg
   return new_msg;
 }
 
+std::shared_ptr<void> Dbc3Api::ParseSteeringRpt(const cn_msgs::Frame& can_msg)
+{
+  auto new_msg = std::make_shared<pm_msgs::SystemRptFloat>();
+
+  STEERING_RPT_t parsed_rpt;
+  Unpack_STEERING_RPT_pacmod3(&parsed_rpt, static_cast<const uint8_t*>(&can_msg.data[0]), static_cast<uint8_t>(can_msg.dlc));
+
+  new_msg->enabled = parsed_rpt.ENABLED;
+  new_msg->override_active = parsed_rpt.OVERRIDE_ACTIVE;
+  new_msg->command_output_fault = parsed_rpt.COMMAND_OUTPUT_FAULT;
+  new_msg->input_output_fault = parsed_rpt.INPUT_OUTPUT_FAULT;
+  new_msg->output_reported_fault = parsed_rpt.OUTPUT_REPORTED_FAULT;
+  new_msg->pacmod_fault = parsed_rpt.PACMOD_FAULT;
+  new_msg->vehicle_fault = parsed_rpt.VEHICLE_FAULT;
+  new_msg->command_timeout = 0;  // dbc3 doesn't have this field
+  new_msg->manual_input = parsed_rpt.MANUAL_INPUT_phys;
+  new_msg->command = parsed_rpt.COMMANDED_VALUE_phys;
+  new_msg->output = parsed_rpt.OUTPUT_VALUE_phys;
+
+  return new_msg;
+}
+
 std::shared_ptr<void> Dbc3Api::ParseSystemRptInt(const cn_msgs::Frame& can_msg)
 {
   auto new_msg = std::make_shared<pm_msgs::SystemRptInt>();


### PR DESCRIPTION
use autogen STERING_RPT_t struct to unpack steering_rpt instead of generic system_rpt_float (need signed ints). 